### PR TITLE
Create shared wrapper around native code

### DIFF
--- a/android/src/main/java/com/rlynetworkmobilesdk/RlyNetworkMobileSdkModule.kt
+++ b/android/src/main/java/com/rlynetworkmobilesdk/RlyNetworkMobileSdkModule.kt
@@ -12,11 +12,9 @@ class RlyNetworkMobileSdkModule(reactContext: ReactApplicationContext) :
     return NAME
   }
 
-  // Example method
-  // See https://reactnative.dev/docs/native-modules-android
   @ReactMethod
-  fun multiply(a: Double, b: Double, promise: Promise) {
-    promise.resolve(a * b)
+  fun hello() {
+    promise.resolve("Hello world")
   }
 
   companion object {

--- a/ios/RlyNetworkMobileSdk.m
+++ b/ios/RlyNetworkMobileSdk.m
@@ -2,14 +2,15 @@
 
 @interface RCT_EXTERN_MODULE(RlyNetworkMobileSdk, NSObject)
 
-RCT_EXTERN_METHOD(getBundleId:
+RCT_EXTERN_METHOD(hello:
     (RCTPromiseResolveBlock) resolve
     rejecter: (RCTPromiseRejectBlock) reject
 )
 
-RCT_EXTERN_METHOD(multiply:(float)a withB:(float)b
-                 withResolver:(RCTPromiseResolveBlock)resolve
-                 withRejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(getBundleId:
+    (RCTPromiseResolveBlock) resolve
+    rejecter: (RCTPromiseRejectBlock) reject
+)
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/ios/RlyNetworkMobileSdk.swift
+++ b/ios/RlyNetworkMobileSdk.swift
@@ -1,10 +1,13 @@
 @objc(RlyNetworkMobileSdk)
 class RlyNetworkMobileSdk: NSObject {
 
-  @objc(multiply:withB:withResolver:withRejecter:)
-  func multiply(a: Float, b: Float, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
-    resolve(a*b)
+  @objc public func hello(
+    _ resolve: RCTPromiseResolveBlock,
+    rejecter reject: RCTPromiseRejectBlock
+  ) -> Void {
+    resolve("Hello World")
   }
+
   @objc public func getBundleId(
     _ resolve: RCTPromiseResolveBlock,
     rejecter reject: RCTPromiseRejectBlock

--- a/src/gsnClient/gsnTxHelpers.ts
+++ b/src/gsnClient/gsnTxHelpers.ts
@@ -1,5 +1,4 @@
 import { ethers, BigNumber } from 'ethers';
-import { NativeModules } from 'react-native';
 import { Buffer } from 'buffer';
 import { TypedGsnRequestData } from './EIP712/typedSigning';
 import type { RelayRequest } from './EIP712/RelayRequest';
@@ -17,8 +16,7 @@ import { tokenFaucet } from '../contract';
 
 import relayHubAbi from './ABI/IRelayHub.json';
 import forwarderAbi from './ABI/IForwarder.json';
-
-const { RlyNetworkMobileSdk } = NativeModules;
+import { NativeCodeWrapper } from 'src/native_code_wrapper';
 
 const calculateCalldataBytesZeroNonzero = (
   calldata: PrefixedHexString
@@ -233,7 +231,7 @@ export const getTransferTx = async (
 export const getClientId = async (): Promise<string> => {
   //get bundleId string from application convert it to integer for use in GSN
   //get bundle id from native module
-  const bundleId = await RlyNetworkMobileSdk.getBundleId();
+  const bundleId = await NativeCodeWrapper.getBundleId();
   //convert bundle to hex
   const hexValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(bundleId));
   //convert hex to int

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,25 +1,2 @@
-import { NativeModules, Platform } from 'react-native';
-
-const LINKING_ERROR =
-  `The package 'rly-network-mobile-sdk' doesn't seem to be linked. Make sure: \n\n` +
-  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
-  '- You rebuilt the app after installing the package\n' +
-  '- You are not using Expo Go\n';
-
-const RlyNetworkMobileSdk = NativeModules.RlyNetworkMobileSdk
-  ? NativeModules.RlyNetworkMobileSdk
-  : new Proxy(
-      {},
-      {
-        get() {
-          throw new Error(LINKING_ERROR);
-        },
-      }
-    );
-
-export function multiply(a: number, b: number): Promise<number> {
-  return RlyNetworkMobileSdk.multiply(a, b);
-}
-
 export { getAccount, getAccountPhrase, createAccount } from './account';
 export * from './network';

--- a/src/native_code_wrapper.ts
+++ b/src/native_code_wrapper.ts
@@ -1,0 +1,27 @@
+import { NativeModules, Platform } from 'react-native';
+
+const LINKING_ERROR =
+  `The package 'rly-network-mobile-sdk' doesn't seem to be linked. Make sure: \n\n` +
+  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
+  '- You rebuilt the app after installing the package\n' +
+  '- You are not using Expo Go\n';
+
+const RlyNativeModule = NativeModules.RlyNetworkMobileSdk
+  ? NativeModules.RlyNetworkMobileSdk
+  : new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
+      }
+    );
+
+export const NativeCodeWrapper = {
+  hello: (): Promise<string> => {
+    return RlyNativeModule.hello();
+  },
+  getBundleId: (): Promise<string> => {
+    return RlyNativeModule.getBundleId();
+  },
+};


### PR DESCRIPTION
Provides a nice, typesafe interface the TS layer can interact with. Also
allows all the error checking around linking to be consolidated into 1
place for better error tracking.

I also cleaned up some old demo code around "multiply" that is no longer
needed since we have other native code to test linking with
