### PR TITLE
[WIP] Add passthrough for configuring keychain storage options

### DIFF
--- a/android/src/main/java/com/rlynetworkmobilesdk/RlyNetworkMobileSdkModule.kt
+++ b/android/src/main/java/com/rlynetworkmobilesdk/RlyNetworkMobileSdkModule.kt
@@ -51,7 +51,7 @@ class RlyNetworkMobileSdkModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun saveMnemonic(mnemonic:String, promise:Promise){
+  fun saveMnemonic(mnemonic:String, keychainAccessible: Integer, promise:Promise){
     if (!MnemonicWords(mnemonic).validate(WORDLIST_ENGLISH)) {
       promise.reject("mnemonic_verification_failure", "mnemonic failed to pass check");
       return;

--- a/ios/KeychainHelper.swift
+++ b/ios/KeychainHelper.swift
@@ -5,13 +5,14 @@ final class KeychainHelper {
     static let standard = KeychainHelper()
     private init() {}
     
-    func save(_ data: Data, service: String, account: String) {
+    func save(_ data: Data, service: String, account: String, keychainAccessible: Int) {
 
         let query = [
             kSecValueData: data,
             kSecAttrService: service,
             kSecAttrAccount: account,
-            kSecClass: kSecClassGenericPassword
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccessible: attributeWith(KeychainAccessible(rawValue: keychainAccessible)!)
         ] as CFDictionary
 
         // Add data in query to keychain
@@ -57,5 +58,34 @@ final class KeychainHelper {
         
         // Delete item from keychain
         SecItemDelete(query)
+    }
+
+    enum KeychainAccessible: Int {
+        case afterFirstUnlock = 0
+        case afterFirstUnlockThisDeviceOnly = 1
+        case always = 2
+        case whenPasscodeSetThisDeviceOnly = 3
+        case alwaysThisDeviceOnly = 4
+        case whenUnlocked = 5
+        case whenUnlockedThisDeviceOnly = 6
+    }
+
+    private func attributeWith(_ option: KeychainAccessible) -> CFString {
+        switch option {
+            case .afterFirstUnlock:
+                return kSecAttrAccessibleAfterFirstUnlock
+            case .afterFirstUnlockThisDeviceOnly:
+                return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            case .always:
+                return kSecAttrAccessibleAlways
+            case .whenPasscodeSetThisDeviceOnly:
+                return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
+            case .alwaysThisDeviceOnly:
+                return kSecAttrAccessibleAlwaysThisDeviceOnly
+            case .whenUnlockedThisDeviceOnly:
+                return kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            default:
+                return kSecAttrAccessibleWhenUnlocked
+        }
     }
 }

--- a/ios/RlyNetworkMobileSdk.m
+++ b/ios/RlyNetworkMobileSdk.m
@@ -25,6 +25,7 @@ RCT_EXTERN_METHOD(generateMnemonic:
 
 RCT_EXTERN_METHOD(saveMnemonic:
     (NSString) mnemonic
+    keychainAccessible: (NSInteger) keychainAccessible
     resolver: (RCTPromiseResolveBlock) resolve
     rejecter: (RCTPromiseRejectBlock) reject
 )

--- a/ios/RlyNetworkMobileSdk.swift
+++ b/ios/RlyNetworkMobileSdk.swift
@@ -55,10 +55,11 @@ class RlyNetworkMobileSdk: NSObject {
     
     @objc public func saveMnemonic(
       _ mnemonic: String,
+      keychainAccessible: Int,
       resolver resolve: RCTPromiseResolveBlock,
       rejecter reject: RCTPromiseRejectBlock
     ) -> Void {
-        KeychainHelper.standard.save(mnemonic.data(using: .utf8)!, service: SERVICE_KEY, account: MNEMONIC_ACCOUNT_KEY)
+        KeychainHelper.standard.save(mnemonic.data(using: .utf8)!, service: SERVICE_KEY, account: MNEMONIC_ACCOUNT_KEY, keychainAccessible: keychainAccessible)
 
         resolve(true)
     }

--- a/src/keyManager.ts
+++ b/src/keyManager.ts
@@ -1,9 +1,10 @@
 import { NativeModules } from 'react-native';
+import type { KeychainAccessibilityConstant } from './keyManagerConstants';
 
 interface KeyManager {
   getMnemonic: () => Promise<string | null>;
   generateMnemonic: () => Promise<string>;
-  saveMnemonic: (mnemonic: string) => Promise<void>;
+  saveMnemonic: (mnemonic: string, keychainAccessible?: KeychainAccessibilityConstant) => Promise<void>;
   deleteMnemonic: () => Promise<void>;
   getPrivateKeyFromMnemonic: (mnemonic: string) => Promise<Uint8Array>;
 }

--- a/src/keyManagerConstants.ts
+++ b/src/keyManagerConstants.ts
@@ -1,0 +1,9 @@
+export type KeychainAccessibilityConstant = number;
+
+export const AFTER_FIRST_UNLOCK: KeychainAccessibilityConstant = 0;
+export const AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: KeychainAccessibilityConstant = 1;
+export const ALWAYS: KeychainAccessibilityConstant = 2;
+export const WHEN_PASSCODE_SET_THIS_DEVICE_ONLY: KeychainAccessibilityConstant = 3;
+export const ALWAYS_THIS_DEVICE_ONLY: KeychainAccessibilityConstant = 4;
+export const WHEN_UNLOCKED: KeychainAccessibilityConstant = 5;
+export const WHEN_UNLOCKED_THIS_DEVICE_ONLY: KeychainAccessibilityConstant = 6;

--- a/src/keyManagerExpo.ts
+++ b/src/keyManagerExpo.ts
@@ -1,4 +1,5 @@
 import { utils, Wallet } from 'ethers';
+import { KeychainAccessibilityConstant, WHEN_UNLOCKED } from './keyManagerConstants';
 
 type ExpoObject = {
   modules: undefined | { [key: string]: any };
@@ -12,9 +13,17 @@ declare global {
 const LINKING_ERROR =
   "The package 'expo-secure-store' doesn't seem to be available please install it as a dependency if using expo.";
 
+
+type SecureStoreOptions = {
+  keychainService?: string;
+  requireAuthentication?: boolean;
+  authenticationPrompt?: string;
+  keychainAccessible?: KeychainAccessibilityConstant;
+};
+
 let SecureStore: {
   getItemAsync: (mnemonic: string) => Promise<string | null>;
-  setItemAsync: (key: string, value: string) => Promise<void>;
+  setItemAsync: (key: string, value: string, options: SecureStoreOptions) => Promise<void>;
   deleteItemAsync: (key: string) => Promise<void>;
 };
 
@@ -38,8 +47,8 @@ export const generateMnemonic = async (): Promise<string> => {
   return utils.entropyToMnemonic(utils.randomBytes(24));
 };
 
-export const saveMnemonic = async (mnemonic: string): Promise<void> => {
-  return SecureStore.setItemAsync(MNEMONIC_ACCOUNT_KEY, mnemonic);
+export const saveMnemonic = async (mnemonic: string, keychainAccessible: KeychainAccessibilityConstant = WHEN_UNLOCKED): Promise<void> => {
+  return SecureStore.setItemAsync(MNEMONIC_ACCOUNT_KEY, mnemonic, { keychainAccessible });
 };
 
 export const deleteMnemonic = async (): Promise<void> => {

--- a/src/keyManagerNativeModule.ts
+++ b/src/keyManagerNativeModule.ts
@@ -1,4 +1,5 @@
 import { NativeModules, Platform } from 'react-native';
+import { KeychainAccessibilityConstant, WHEN_UNLOCKED } from './keyManagerConstants';
 
 const LINKING_ERROR =
   `The package 'rly-network-mobile-sdk' doesn't seem to be linked. Make sure: \n\n` +
@@ -9,13 +10,13 @@ const LINKING_ERROR =
 const RlyNativeModule = NativeModules.RlyNetworkMobileSdk
   ? NativeModules.RlyNetworkMobileSdk
   : new Proxy(
-      {},
-      {
-        get() {
-          throw new Error(LINKING_ERROR);
-        },
-      }
-    );
+    {},
+    {
+      get() {
+        throw new Error(LINKING_ERROR);
+      },
+    }
+  );
 
 export const getMnemonic = async (): Promise<string | null> => {
   return RlyNativeModule.getMnemonic();
@@ -25,8 +26,8 @@ export const generateMnemonic = async (): Promise<string> => {
   return RlyNativeModule.generateMnemonic();
 };
 
-export const saveMnemonic = async (mnemonic: string): Promise<void> => {
-  return RlyNativeModule.saveMnemonic(mnemonic);
+export const saveMnemonic = async (mnemonic: string, keychainAccessible: KeychainAccessibilityConstant = WHEN_UNLOCKED): Promise<void> => {
+  return RlyNativeModule.saveMnemonic(mnemonic, keychainAccessible);
 };
 
 export const deleteMnemonic = async (): Promise<void> => {


### PR DESCRIPTION
This will allow external developers the option to configure how the mnemonic is stored in the ios device keychain. 

- [x] Add some form of android support that ignores iOS options