### PR TITLE
Update pkey getter to trim hardened key leading 0x00 for ethersjs

### DIFF
--- a/android/src/main/java/com/rlynetworkmobilesdk/RlyNetworkMobileSdkModule.kt
+++ b/android/src/main/java/com/rlynetworkmobilesdk/RlyNetworkMobileSdkModule.kt
@@ -1,7 +1,5 @@
 package com.rlynetworkmobilesdk
 
-import android.content.Context
-import androidx.security.crypto.MasterKey
 import com.facebook.react.bridge.*
 import org.kethereum.bip39.generateMnemonic
 import org.kethereum.bip39.validate
@@ -9,10 +7,8 @@ import org.kethereum.bip39.dirtyPhraseToMnemonicWords
 import org.kethereum.bip39.toSeed
 import org.kethereum.bip39.wordlists.WORDLIST_ENGLISH
 import org.kethereum.bip39.model.MnemonicWords
-import org.kethereum.bip32.model.ExtendedKey
 import org.kethereum.bip32.toKey
 import org.kethereum.extensions.*
-import java.lang.Integer.parseInt
 
 class RlyNetworkMobileSdkModule(reactContext: ReactApplicationContext) :
   ReactContextBaseJavaModule(reactContext) {
@@ -78,7 +74,11 @@ class RlyNetworkMobileSdkModule(reactContext: ReactApplicationContext) :
     val seed = words.toSeed()
     val key = seed.toKey("m/44'/60'/0'/0/0")
 
-    val privateKey = key.keyPair.privateKey.key.toByteArray()
+    var privateKey = key.keyPair.privateKey.key.toByteArray()
+
+    if (privateKey.size == 33 && privateKey[0].toInt() == 0) {
+      privateKey = privateKey.removeLeadingZero()
+    }
 
     val result = WritableNativeArray();
     // and 0xFF fixes twos complement integer representation and

--- a/src/keyManagerNativeModule.ts
+++ b/src/keyManagerNativeModule.ts
@@ -36,11 +36,5 @@ export const deleteMnemonic = async (): Promise<void> => {
 export const getPrivateKeyFromMnemonic = async (
   mnemonic: string
 ): Promise<Uint8Array> => {
-  let pkey = await RlyNativeModule.getPrivateKeyFromMnemonic(mnemonic);
-
-  if (pkey.length === 33 && pkey[0] === 0x00) {
-    pkey = pkey.slice(1);
-  }
-
-  return pkey;
+  return RlyNativeModule.getPrivateKeyFromMnemonic(mnemonic);
 };

--- a/src/keyManagerNativeModule.ts
+++ b/src/keyManagerNativeModule.ts
@@ -36,5 +36,11 @@ export const deleteMnemonic = async (): Promise<void> => {
 export const getPrivateKeyFromMnemonic = async (
   mnemonic: string
 ): Promise<Uint8Array> => {
-  return RlyNativeModule.getPrivateKeyFromMnemonic(mnemonic);
+  let pkey = await RlyNativeModule.getPrivateKeyFromMnemonic(mnemonic);
+
+  if (pkey.length === 33 && pkey[0] === 0x00) {
+    pkey = pkey.slice(1);
+  }
+
+  return pkey;
 };


### PR DESCRIPTION
KEthereum will add a leading 0x00 byte if the key is hardened flagged, see:

https://github.com/komputing/KEthereum/blob/2f8c1dad6bea1eac0484e416e45cf45ce8d9d782/bip32/src/main/kotlin/org/kethereum/bip32/BIP32.kt#L59-L65

ethersjs does not expect this leading 0x00 byte so we remove it if it is detected