### PR TITLE
Update method name for calling faucet contract

### DIFF
--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -111,7 +111,7 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
             <View style={styles.alignMiddle}>
               <BodyText>Register My Account</BodyText>
             </View>
-            <Button onPress={claimRlyTokens} title="Register" />
+            <Button onPress={claimRlyTokens} title="Claim RLY" />
           </RlyCard>
 
           <RlyCard style={styles.balanceCard}>

--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -43,9 +43,9 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
     fetchBalance();
   }, []);
 
-  const registerAccount = async () => {
+  const claimRlyTokens = async () => {
     setPerformingAction('Registering Account');
-    await RlyNetwork.registerAccount();
+    await RlyNetwork.claimRly();
 
     await fetchBalance();
     setPerformingAction(undefined);
@@ -111,7 +111,7 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
             <View style={styles.alignMiddle}>
               <BodyText>Register My Account</BodyText>
             </View>
-            <Button onPress={registerAccount} title="Register" />
+            <Button onPress={claimRlyTokens} title="Register" />
           </RlyCard>
 
           <RlyCard style={styles.balanceCard}>

--- a/example_expo/src/AccountOverviewScreen.tsx
+++ b/example_expo/src/AccountOverviewScreen.tsx
@@ -102,7 +102,7 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
             <View style={styles.alignMiddle}>
               <BodyText>Register My Account</BodyText>
             </View>
-            <Button onPress={claimRlyTokens} title="Register" />
+            <Button onPress={claimRlyTokens} title="Claim RLY" />
           </RlyCard>
 
           <RlyCard style={styles.balanceCard}>

--- a/example_expo/src/AccountOverviewScreen.tsx
+++ b/example_expo/src/AccountOverviewScreen.tsx
@@ -38,9 +38,9 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
     fetchBalance();
   }, []);
 
-  const registerAccount = async () => {
+  const claimRlyTokens = async () => {
     setPerformingAction('Registering Account');
-    await RlyNetwork.registerAccount();
+    await RlyNetwork.claimRly();
 
     await fetchBalance();
     setPerformingAction(undefined);
@@ -102,7 +102,7 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
             <View style={styles.alignMiddle}>
               <BodyText>Register My Account</BodyText>
             </View>
-            <Button onPress={registerAccount} title="Register" />
+            <Button onPress={claimRlyTokens} title="Register" />
           </RlyCard>
 
           <RlyCard style={styles.balanceCard}>

--- a/src/__tests__/integration/transaction.test.ts
+++ b/src/__tests__/integration/transaction.test.ts
@@ -31,10 +31,23 @@ jest.mock('react-native', () => {
 });
 
 testOnlyRunInCIFullSuite(
-  'claim mumbai',
+  'claim mumbai legacy method name',
   async () => {
     const oldBal = await RlyMumbaiNetwork.getBalance();
     const txHash = await RlyMumbaiNetwork.registerAccount();
+    const newBal = await RlyMumbaiNetwork.getBalance();
+    expect(oldBal).toEqual(0);
+    expect(txHash).toMatch(/^0x/);
+    expect(newBal).toEqual(10);
+  },
+  30000
+);
+
+testOnlyRunInCIFullSuite(
+  'claim mumbai',
+  async () => {
+    const oldBal = await RlyMumbaiNetwork.getBalance();
+    const txHash = await RlyMumbaiNetwork.claimRly();
     const newBal = await RlyMumbaiNetwork.getBalance();
     expect(oldBal).toEqual(0);
     expect(txHash).toMatch(/^0x/);

--- a/src/__tests__/integration/transaction.test.ts
+++ b/src/__tests__/integration/transaction.test.ts
@@ -59,7 +59,7 @@ testOnlyRunInCIFullSuite(
 test('claim local', async () => {
   const account = await getWallet();
   const oldBal = await RlyDummyNetwork.getBalance();
-  const txHash = await RlyDummyNetwork.registerAccount();
+  const txHash = await RlyDummyNetwork.claimRly();
   const newBal = await RlyDummyNetwork.getBalance();
   expect(oldBal).toEqual(0);
   expect(txHash).toEqual(`success_${10}_${account?.publicKey}`);

--- a/src/network.ts
+++ b/src/network.ts
@@ -19,6 +19,8 @@ export interface Network {
     tokenAddress?: PrefixedHexString,
     metaTxMethod?: MetaTxMethod
   ) => Promise<string>;
+  claimRly: () => Promise<string>;
+  //Deprecated please use claimRly instead
   registerAccount: () => Promise<string>;
   relay?: (tx: GsnTransactionDetails) => Promise<string>;
   setApiKey: (apiKey: string) => void;

--- a/src/networks/dummy_network.ts
+++ b/src/networks/dummy_network.ts
@@ -39,7 +39,14 @@ async function getBalance() {
   return balances[wallet.publicKey] || 0;
 }
 
+// This method is deprecated. Update to 'claimRly' instead.
+// Will be removed in future library versions.
 async function registerAccount() {
+  console.error("This method is deprecated. Update to 'claimRly' instead.");
+  return claimRly();
+}
+
+async function claimRly() {
   const account = await getWallet();
   if (!account) {
     throw MissingWalletError;
@@ -61,6 +68,7 @@ function setApiKey(apiKeyParam: string) {
 export const RlyDummyNetwork: Network = {
   transfer: transfer,
   getBalance: getBalance,
+  claimRly: claimRly,
   registerAccount: registerAccount,
   setApiKey: setApiKey,
 };

--- a/src/networks/evm_network.ts
+++ b/src/networks/evm_network.ts
@@ -137,7 +137,7 @@ async function getBalance(
   return Number(ethers.utils.formatUnits(bal.toString(), decimals));
 }
 
-async function registerAccount(network: NetworkConfig): Promise<string> {
+async function claimRly(network: NetworkConfig): Promise<string> {
   const account = await getWallet();
   if (!account) {
     throw MissingWalletError;
@@ -154,6 +154,14 @@ async function registerAccount(network: NetworkConfig): Promise<string> {
   const claimTx = await getClaimTx(account, network, provider);
 
   return relay(claimTx, network);
+}
+
+// This method is deprecated. Update to 'claimRly' instead.
+// Will be removed in future library versions.
+async function registerAccount(network: NetworkConfig): Promise<string> {
+  console.error("This method is deprecated. Update to 'claimRly' instead.");
+
+  return claimRly(network);
 }
 
 export async function relay(
@@ -187,6 +195,11 @@ export function getEvmNetwork(network: NetworkConfig) {
     getBalance: function (tokenAddress?: PrefixedHexString) {
       return getBalance(network, tokenAddress);
     },
+    claimRly: function () {
+      return claimRly(network);
+    },
+    // This method is deprecated. Update to 'claimRly' instead.
+    // Will be removed in future library versions.
     registerAccount: function () {
       return registerAccount(network);
     },


### PR DESCRIPTION
registerAccount was causing some confusion, and what the method actually
does is allow caller to claim RLY tokens. This updates the method name,
but leaves in place the older method with a deprecation warning.
