### PR TITLE
Update mnemonic storage to return null if not found like other platforms

### DIFF
--- a/android/src/main/java/com/rlynetworkmobilesdk/MnemonicStorageHelper.kt
+++ b/android/src/main/java/com/rlynetworkmobilesdk/MnemonicStorageHelper.kt
@@ -5,7 +5,6 @@ import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import androidx.security.crypto.MasterKey.Builder
-import com.facebook.react.bridge.Promise
 import com.google.android.gms.auth.blockstore.*
 
 class MnemonicStorageHelper(context: Context) {
@@ -62,7 +61,7 @@ class MnemonicStorageHelper(context: Context) {
     editor.commit()
   }
 
-  fun read(key: String, onSuccess: (mnemonic: String) -> Unit, onFailure: (message: String) -> Unit) {
+  fun read(key: String, onSuccess: (mnemonic: String?) -> Unit) {
 
     val retrieveRequest = RetrieveBytesRequest.Builder()
       .setKeys(listOf(key))
@@ -74,27 +73,19 @@ class MnemonicStorageHelper(context: Context) {
 
         if (blockstoreDataMap.isEmpty()) {
           val mnemonic = readFromSharedPref(key)
-          if (mnemonic != null) {
-            onSuccess(mnemonic)
-          } else {
-            onFailure("no mnemonic found in cloud or device storage")
-          }
+          onSuccess(mnemonic)
         } else {
-          val value = blockstoreDataMap[key]
-          if (value != null) {
-            onSuccess(value.bytes.toString(Charsets.UTF_8))
+          val mnemonic = blockstoreDataMap[key]
+          if (mnemonic !== null) {
+            onSuccess(mnemonic.bytes.toString(Charsets.UTF_8))
           } else {
-            onFailure("no mnemonic found in cloud or device storage")
+            onSuccess(null)
           }
         }
       }
       .addOnFailureListener {
         val mnemonic = readFromSharedPref(key)
-        if (mnemonic != null) {
-          onSuccess(mnemonic)
-        } else {
-          onFailure("no mnemonic found in cloud or device storage")
-        }
+        onSuccess(mnemonic)
       }
   }
 

--- a/android/src/main/java/com/rlynetworkmobilesdk/RlyNetworkMobileSdkModule.kt
+++ b/android/src/main/java/com/rlynetworkmobilesdk/RlyNetworkMobileSdkModule.kt
@@ -36,11 +36,9 @@ class RlyNetworkMobileSdkModule(reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun getMnemonic(promise:Promise){
-    mnemonicHelper.read(MNEMONIC_STORAGE_KEY, { mnemonic ->
+    mnemonicHelper.read(MNEMONIC_STORAGE_KEY) { mnemonic: String? ->
       promise.resolve(mnemonic)
-    }, { message ->
-      promise.reject("mnemonic_read_failure", message)
-    })
+    }
   }
 
   @ReactMethod
@@ -58,7 +56,7 @@ class RlyNetworkMobileSdkModule(reactContext: ReactApplicationContext) :
 
     mnemonicHelper.save(MNEMONIC_STORAGE_KEY, mnemonic, saveToCloud, rejectOnCloudSaveFailure, { ->
       promise.resolve(true)
-    }, { message ->
+    }, { message: String ->
       promise.reject("mnemonic_save_failure", message)
     })
   }


### PR DESCRIPTION
When adding in the cloud sync feature on android the promise strategy was updated to reject of mnemonic was not found. This was unlike the other supported platforms (expo/iOS) 

This updates android to return null instead of rejecting promises.