### PR TITLE
update example app transfer call

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -368,7 +368,7 @@ PODS:
     - React-jsi (= 0.70.8)
     - React-logger (= 0.70.8)
     - React-perflogger (= 0.70.8)
-  - rly-network-mobile-sdk (1.1.0-beta.2):
+  - rly-network-mobile-sdk (1.1.0):
     - React-Core
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -574,7 +574,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 19d21a3ed620352180800447771f68a101f196e9
   React-runtimeexecutor: f795fd426264709901c09432c6ce072f8400147e
   ReactCommon: c440e7f15075e81eb29802521c58a1f38b1aa903
-  rly-network-mobile-sdk: 2d14c8282a906f8b1ac7dba94a1c0819c25e5e8b
+  rly-network-mobile-sdk: 23d2ec9c235e7aa01c9f5f0b8f57512be18295e0
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: d6133108734e69e8c0becc6ba587294b94829687
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -15,6 +15,7 @@ import {
   getAccountPhrase,
   RlyMumbaiNetwork,
   permanentlyDeleteAccount,
+  MetaTxMethod,
 } from '@rly-network/mobile-sdk';
 import { RlyCard } from './components/RlyCard';
 import { LoadingModal, StandardModal } from './components/LoadingModal';
@@ -65,7 +66,8 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
       await RlyNetwork.transfer(
         transferAddress,
         parseInt(transferBalance, 10),
-        customTokenAddress
+        customTokenAddress,
+        MetaTxMethod.ExecuteMetaTransaction
       );
       await fetchBalance();
       setTransferBalance('');

--- a/example_expo/src/AccountOverviewScreen.tsx
+++ b/example_expo/src/AccountOverviewScreen.tsx
@@ -10,13 +10,19 @@ import {
   View,
 } from 'react-native';
 import { useEffect, useState } from 'react';
-import { getAccountPhrase, RlyMumbaiNetwork } from '@rly-network/mobile-sdk';
+import {
+  getAccountPhrase,
+  RlyMumbaiNetwork,
+  MetaTxMethod,
+} from '@rly-network/mobile-sdk';
 import { RlyCard } from './components/RlyCard';
 import { LoadingModal, StandardModal } from './components/LoadingModal';
 import { PrivateConfig } from './private_config';
 
 const RlyNetwork = RlyMumbaiNetwork;
 RlyNetwork.setApiKey(PrivateConfig.RALLY_API_KEY);
+
+const customTokenAddress: string | undefined = undefined;
 
 export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
   const [performingAction, setPerformingAction] = useState<string>();
@@ -48,7 +54,12 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
 
   const transferTokens = async () => {
     setPerformingAction('Transfering Tokens');
-    await RlyNetwork.transfer(transferAddress, parseInt(transferBalance, 10));
+    await RlyNetwork.transfer(
+      transferAddress,
+      parseInt(transferBalance, 10),
+      customTokenAddress,
+      MetaTxMethod.ExecuteMetaTransaction
+    );
 
     await fetchBalance();
     setPerformingAction(undefined);


### PR DESCRIPTION
- update expo example to include `customTokenAddress` that is used in RN example.
- add metaTxMethod argument to transfer calls in both example apps