### PR TITLE
Import existing account functionality

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -191,6 +191,8 @@ workflows:
         bundle_identifier: network.rly.example.RlyNetworkMobileSdkExample
       vars:
         BUNDLE_ID: 'network.rly.example.RlyNetworkMobileSdkExample'
+      groups:
+        - full-suite-tests
     cache:
       cache_paths:
         - $CM_BUILD_DIR/node_modules
@@ -362,6 +364,7 @@ workflows:
       <<: *default_environments
       groups:
         - publish-npm-group
+        - full-suite-tests
     cache:
       cache_paths:
         - $CM_BUILD_DIR/node_modules

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,7 +1,7 @@
 definitions:
   default_environments: &default_environments
     node: 16.14.2
-    npm: latest
+    npm: 9.8.1
   trigger_on_main_push: &trigger_on_main_push
     triggering:
       events:

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -368,7 +368,7 @@ PODS:
     - React-jsi (= 0.70.8)
     - React-logger (= 0.70.8)
     - React-perflogger (= 0.70.8)
-  - rly-network-mobile-sdk (1.1.0):
+  - rly-network-mobile-sdk (1.1.2):
     - React-Core
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -574,7 +574,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 19d21a3ed620352180800447771f68a101f196e9
   React-runtimeexecutor: f795fd426264709901c09432c6ce072f8400147e
   ReactCommon: c440e7f15075e81eb29802521c58a1f38b1aa903
-  rly-network-mobile-sdk: 23d2ec9c235e7aa01c9f5f0b8f57512be18295e0
+  rly-network-mobile-sdk: d4394df6461fb1d3c63d8df22d0775af30fed470
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: d6133108734e69e8c0becc6ba587294b94829687
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppContainer } from './components/AppContainer';
-import { BodyText, HeadingText } from './components/text';
+import { BodyText, HeadingText, SelectableText } from './components/text';
 import {
   Alert,
   Button,
@@ -101,7 +101,9 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
             <HeadingText>Welcome to RLY</HeadingText>
           </View>
           <View style={styles.addressContainer}>
-            <BodyText>{props.rlyAccount || 'No Account Exists'}</BodyText>
+            <SelectableText>
+              {props.rlyAccount || 'No Account Exists'}
+            </SelectableText>
           </View>
           <RlyCard style={styles.balanceCard}>
             <View style={styles.balanceContainer}>
@@ -181,7 +183,7 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
             <BodyText>Copy The Phrase below to export your wallet</BodyText>
           </View>
           <View style={styles.balanceCard}>
-            <HeadingText>{mnemonic}</HeadingText>
+            <SelectableText>{mnemonic}</SelectableText>
           </View>
           <View style={styles.balanceCard}>
             <Button

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
-import { createAccount, getAccount } from '@rly-network/mobile-sdk';
+import {
+  createAccount,
+  getAccount,
+  importExistingAccount,
+} from '@rly-network/mobile-sdk';
 import { AccountOverviewScreen } from './AccountOverviewScreen';
 import { GenerateAccountScreen } from './GenerateAccountScreen';
 import { LoadingScreen } from './LoadingScreen';
@@ -12,13 +16,18 @@ export default function App() {
 
   useEffect(() => {
     const readAccount = async () => {
-      const account = await getAccount();
-      console.log('user account', account);
+      try {
+        const account = await getAccount();
 
-      setAccountLoaded(true);
+        console.log('user account', account);
 
-      if (account) {
-        setRlyAccount(account);
+        if (account) {
+          setRlyAccount(account);
+        }
+      } catch (error: any) {
+        console.error('Error occurred while reading account', error.message);
+      } finally {
+        setAccountLoaded(true);
       }
     };
 
@@ -28,7 +37,12 @@ export default function App() {
   }, [accountLoaded]);
 
   const createRlyAccount = async () => {
-    const rlyAct = await createAccount();
+    const rlyAct = await createAccount({ overwrite: true });
+    setRlyAccount(rlyAct);
+  };
+
+  const importExistingRlyAccount = async (mnemonic: string) => {
+    const rlyAct = await importExistingAccount(mnemonic);
     setRlyAccount(rlyAct);
   };
 
@@ -37,7 +51,12 @@ export default function App() {
   }
 
   if (!rlyAccount) {
-    return <GenerateAccountScreen generateAccount={createRlyAccount} />;
+    return (
+      <GenerateAccountScreen
+        generateAccount={createRlyAccount}
+        importExistingAccount={importExistingRlyAccount}
+      />
+    );
   }
 
   return <AccountOverviewScreen rlyAccount={rlyAccount} />;

--- a/example/src/GenerateAccountScreen.tsx
+++ b/example/src/GenerateAccountScreen.tsx
@@ -1,12 +1,24 @@
 import * as React from 'react';
-import { View, Button, StyleSheet } from 'react-native';
+import { useState } from 'react';
+import { Alert, View, Button, StyleSheet, TextInput } from 'react-native';
 import { AppContainer } from './components/AppContainer';
 import { RlyCard } from './components/RlyCard';
 import { BodyText, HeadingText } from './components/text';
 
 export const GenerateAccountScreen = (props: {
   generateAccount: () => void;
+  importExistingAccount: (arg0: string) => void;
 }) => {
+  const [existingMnemonic, setExistingMnemonic] = useState('');
+
+  const importButtonPress = () => {
+    if (!existingMnemonic) {
+      Alert.alert('Mnemonic is empty');
+      return;
+    }
+    props.importExistingAccount(existingMnemonic);
+  };
+
   return (
     <AppContainer>
       <View>
@@ -18,6 +30,20 @@ export const GenerateAccountScreen = (props: {
         </View>
         <Button title="Create RLY Account" onPress={props.generateAccount} />
       </RlyCard>
+
+      <RlyCard style={styles.cardMargin}>
+        <View style={styles.marginBetween}>
+          <BodyText>...or import an existing mnemonic</BodyText>
+        </View>
+        <TextInput
+          secureTextEntry={true}
+          style={styles.input}
+          value={existingMnemonic}
+          onChangeText={setExistingMnemonic}
+        />
+
+        <Button title="Import Existing Account" onPress={importButtonPress} />
+      </RlyCard>
     </AppContainer>
   );
 };
@@ -28,5 +54,14 @@ const styles = StyleSheet.create({
   },
   cardMargin: {
     marginTop: 24,
+  },
+  input: {
+    height: 40,
+    padding: 10,
+    marginVertical: 12,
+    color: 'white',
+    backgroundColor: '#3A3A3A',
+    borderRadius: 8,
+    borderWidth: 0,
   },
 });

--- a/example/src/components/text.tsx
+++ b/example/src/components/text.tsx
@@ -9,6 +9,14 @@ export function HeadingText({ children }: { children: React.ReactNode }) {
   return <Text style={styles.headingText}>{children}</Text>;
 }
 
+export function SelectableText({ children }: { children: React.ReactNode }) {
+  return (
+    <Text selectable={true} style={styles.standardText}>
+      {children}
+    </Text>
+  );
+}
+
 const styles = StyleSheet.create({
   standardText: {
     color: '#FFFFFF',

--- a/example_expo/src/AccountOverviewScreen.tsx
+++ b/example_expo/src/AccountOverviewScreen.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from 'react';
 import {
   getAccountPhrase,
   RlyMumbaiNetwork,
+  permanentlyDeleteAccount,
   MetaTxMethod,
 } from '@rly-network/mobile-sdk';
 import { RlyCard } from './components/RlyCard';
@@ -65,6 +66,10 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
     setPerformingAction(undefined);
     setTransferBalance('');
     setTranferAddress('');
+  };
+
+  const deleteAccount = async () => {
+    await permanentlyDeleteAccount();
   };
 
   const revealMnemonic = async () => {
@@ -147,6 +152,16 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
               <BodyText>Export Your Account</BodyText>
             </View>
             <Button title="Reveal my Mnemonic" onPress={revealMnemonic} />
+          </RlyCard>
+
+          <RlyCard style={styles.balanceCard}>
+            <View style={styles.alignMiddle}>
+              <BodyText>Delete Your Account</BodyText>
+            </View>
+            <Button
+              title="Delete my on device account"
+              onPress={deleteAccount}
+            />
           </RlyCard>
         </ScrollView>
       </AppContainer>

--- a/example_expo/src/AccountOverviewScreen.tsx
+++ b/example_expo/src/AccountOverviewScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppContainer } from './components/AppContainer';
-import { BodyText, HeadingText } from './components/text';
+import { BodyText, HeadingText, SelectableText } from './components/text';
 import {
   Button,
   Linking,
@@ -85,7 +85,9 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
             <HeadingText>Welcome to RLY</HeadingText>
           </View>
           <View style={styles.addressContainer}>
-            <BodyText>{props.rlyAccount || 'No Account Exists'}</BodyText>
+            <SelectableText>
+              {props.rlyAccount || 'No Account Exists'}
+            </SelectableText>
           </View>
           <RlyCard style={styles.balanceCard}>
             <View style={styles.balanceContainer}>
@@ -155,7 +157,7 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
             <BodyText>Copy The Phrase below to export your wallet</BodyText>
           </View>
           <View style={styles.balanceCard}>
-            <HeadingText>{mnemonic}</HeadingText>
+            <SelectableText>{mnemonic}</SelectableText>
           </View>
           <View style={styles.balanceCard}>
             <Button

--- a/example_expo/src/App.tsx
+++ b/example_expo/src/App.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
-import { createAccount, getAccount } from '@rly-network/mobile-sdk';
+import {
+  createAccount,
+  getAccount,
+  importExistingAccount,
+} from '@rly-network/mobile-sdk';
 import { AccountOverviewScreen } from './AccountOverviewScreen';
 import { GenerateAccountScreen } from './GenerateAccountScreen';
 import { LoadingScreen } from './LoadingScreen';
@@ -12,13 +16,18 @@ export default function App() {
 
   useEffect(() => {
     const readAccount = async () => {
-      const account = await getAccount();
-      console.log('user account', account);
+      try {
+        const account = await getAccount();
 
-      setAccountLoaded(true);
+        console.log('user account', account);
 
-      if (account) {
-        setRlyAccount(account);
+        if (account) {
+          setRlyAccount(account);
+        }
+      } catch (error: any) {
+        console.error('Error occurred while reading account', error.message);
+      } finally {
+        setAccountLoaded(true);
       }
     };
 
@@ -28,7 +37,12 @@ export default function App() {
   }, [accountLoaded]);
 
   const createRlyAccount = async () => {
-    const rlyAct = await createAccount();
+    const rlyAct = await createAccount({ overwrite: true });
+    setRlyAccount(rlyAct);
+  };
+
+  const importExistingRlyAccount = async (mnemonic: string) => {
+    const rlyAct = await importExistingAccount(mnemonic);
     setRlyAccount(rlyAct);
   };
 
@@ -37,7 +51,12 @@ export default function App() {
   }
 
   if (!rlyAccount) {
-    return <GenerateAccountScreen generateAccount={createRlyAccount} />;
+    return (
+      <GenerateAccountScreen
+        generateAccount={createRlyAccount}
+        importExistingAccount={importExistingRlyAccount}
+      />
+    );
   }
 
   return <AccountOverviewScreen rlyAccount={rlyAccount} />;

--- a/example_expo/src/GenerateAccountScreen.tsx
+++ b/example_expo/src/GenerateAccountScreen.tsx
@@ -1,12 +1,24 @@
 import * as React from 'react';
-import { View, Button, StyleSheet } from 'react-native';
+import { useState } from 'react';
+import { Alert, View, Button, StyleSheet, TextInput } from 'react-native';
 import { AppContainer } from './components/AppContainer';
 import { RlyCard } from './components/RlyCard';
 import { BodyText, HeadingText } from './components/text';
 
 export const GenerateAccountScreen = (props: {
   generateAccount: () => void;
+  importExistingAccount: (arg0: string) => void;
 }) => {
+  const [existingMnemonic, setExistingMnemonic] = useState('');
+
+  const importButtonPress = () => {
+    if (!existingMnemonic) {
+      Alert.alert('Mnemonic is empty');
+      return;
+    }
+    props.importExistingAccount(existingMnemonic);
+  };
+
   return (
     <AppContainer>
       <View>
@@ -18,6 +30,19 @@ export const GenerateAccountScreen = (props: {
         </View>
         <Button title="Create RLY Account" onPress={props.generateAccount} />
       </RlyCard>
+      <RlyCard style={styles.cardMargin}>
+        <View style={styles.marginBetween}>
+          <BodyText>...or import an existing mnemonic</BodyText>
+        </View>
+        <TextInput
+          secureTextEntry={true}
+          style={styles.input}
+          value={existingMnemonic}
+          onChangeText={setExistingMnemonic}
+        />
+
+        <Button title="Import Existing Account" onPress={importButtonPress} />
+      </RlyCard>
     </AppContainer>
   );
 };
@@ -28,5 +53,14 @@ const styles = StyleSheet.create({
   },
   cardMargin: {
     marginTop: 24,
+  },
+  input: {
+    height: 40,
+    padding: 10,
+    marginVertical: 12,
+    color: 'white',
+    backgroundColor: '#3A3A3A',
+    borderRadius: 8,
+    borderWidth: 0,
   },
 });

--- a/example_expo/src/components/text.tsx
+++ b/example_expo/src/components/text.tsx
@@ -9,6 +9,14 @@ export function HeadingText({ children }: { children: React.ReactNode }) {
   return <Text style={styles.headingText}>{children}</Text>;
 }
 
+export function SelectableText({ children }: { children: React.ReactNode }) {
+  return (
+    <Text selectable={true} style={styles.standardText}>
+      {children}
+    </Text>
+  );
+}
+
 const styles = StyleSheet.create({
   standardText: {
     color: '#FFFFFF',

--- a/src/__tests__/account.test.ts
+++ b/src/__tests__/account.test.ts
@@ -1,5 +1,12 @@
 import { utils, Wallet } from 'ethers';
-import { signMessage, getWallet, signTransaction, signHash } from '../account';
+import {
+  createAccount,
+  importExistingAccount,
+  signMessage,
+  getWallet,
+  signTransaction,
+  signHash,
+} from '../account';
 import type { KeyStorageConfig } from 'src/keyManagerTypes';
 
 // mock native code, just testing signing function
@@ -34,6 +41,34 @@ jest.mock('react-native', () => {
       select: jest.fn(),
     },
   };
+});
+
+test('create account', async () => {
+  await expect(createAccount({ overwrite: false })).rejects.toThrow(
+    'Account already exists'
+  );
+
+  const address = await createAccount({ overwrite: true });
+  expect(address).toEqual('0x88046468228953d17c7DAaE39cfEF9B4b082164D');
+});
+
+test('import existing account', async () => {
+  const existingMnemonic =
+    'huge remain palm vanish spike exotic amount scheme window crowd shift spoil';
+  await expect(
+    importExistingAccount(existingMnemonic, { overwrite: false })
+  ).rejects.toThrow('Account already exists');
+
+  const address = await importExistingAccount(existingMnemonic, {
+    overwrite: true,
+  });
+  expect(address).toEqual('0x242F7fDaF2eF119CfdB7F9D0aa7BE1D1C7dA4587');
+
+  // re-creating account should regenerate back to the default
+  const recreatedAddress = await createAccount({ overwrite: true });
+  expect(recreatedAddress).toEqual(
+    '0x88046468228953d17c7DAaE39cfEF9B4b082164D'
+  );
 });
 
 test('sign message', async () => {

--- a/src/__tests__/integration/transaction.test.ts
+++ b/src/__tests__/integration/transaction.test.ts
@@ -1,13 +1,15 @@
 import { Wallet } from 'ethers';
-import { getWallet } from '../../account';
+import { getWallet, permanentlyDeleteAccount } from '../../account';
 import { RlyMumbaiNetwork, RlyDummyNetwork } from '../../network';
-import { testSkipInCI } from '../__utils__/test_utils';
+import { testOnlyRunInCIFullSuite } from '../__utils__/test_utils';
 
 let mockMnemonic: string;
 let mockPk: string;
 
-beforeAll(async () => {
+beforeEach(async () => {
   // need to create new mnemonic for each run so that claim can be called
+  await permanentlyDeleteAccount();
+
   const wallet = Wallet.createRandom();
   mockMnemonic = wallet.mnemonic.phrase;
   mockPk = Wallet.fromMnemonic(mockMnemonic).privateKey;
@@ -30,9 +32,11 @@ jest.mock('react-native', () => {
   };
 });
 
-testSkipInCI(
+testOnlyRunInCIFullSuite(
   'claim mumbai legacy method name',
   async () => {
+    RlyMumbaiNetwork.setApiKey(process.env.RALLY_PROTOCOL_MUMBAI_TOKEN!);
+
     const oldBal = await RlyMumbaiNetwork.getBalance();
     const txHash = await RlyMumbaiNetwork.registerAccount();
     const newBal = await RlyMumbaiNetwork.getBalance();
@@ -43,11 +47,11 @@ testSkipInCI(
   30000
 );
 
-// this can be enabled again (with testOnlyRunInCIFullSuite) if we add an API key for CI
-// (otherwise claimRly fails without an API key)
-testSkipInCI(
+testOnlyRunInCIFullSuite(
   'claim mumbai',
   async () => {
+    RlyMumbaiNetwork.setApiKey(process.env.RALLY_PROTOCOL_MUMBAI_TOKEN!);
+
     const oldBal = await RlyMumbaiNetwork.getBalance();
     const txHash = await RlyMumbaiNetwork.claimRly();
     const newBal = await RlyMumbaiNetwork.getBalance();

--- a/src/account.ts
+++ b/src/account.ts
@@ -44,7 +44,7 @@ async function _createAccountWithMnemonicPromise(
   };
 
   if (existingWallet && !overwrite) {
-    throw 'Account already exists';
+    throw new Error('Account already exists');
   }
 
   const mnemonic = await mnemonicPromise;
@@ -115,7 +115,7 @@ export async function signMessage(message: string): Promise<string> {
   const wallet = await getWallet();
 
   if (!wallet) {
-    throw 'No account';
+    throw new Error('No account');
   }
 
   return wallet.signMessage(message);
@@ -124,7 +124,7 @@ export async function signMessage(message: string): Promise<string> {
 export async function signTransaction(tx: TransactionRequest): Promise<string> {
   const wallet = await getWallet();
   if (!wallet) {
-    throw 'No account';
+    throw new Error('No account');
   }
 
   return wallet.signTransaction(tx);
@@ -133,7 +133,7 @@ export async function signTransaction(tx: TransactionRequest): Promise<string> {
 export async function signHash(hash: string): Promise<string> {
   const wallet = await getWallet();
   if (!wallet) {
-    throw 'No account';
+    throw new Error('No account');
   }
   const signingKey = new utils.SigningKey(wallet.privateKey);
 
@@ -147,7 +147,7 @@ export async function signTypedData(
 ): Promise<string> {
   const wallet = await getWallet();
   if (!wallet) {
-    throw 'No account';
+    throw new Error('No account');
   }
   return await wallet._signTypedData(domain, types, value);
 }


### PR DESCRIPTION
Works similar to `createAccount`, e.g.

```ts
const address = await importExistingAccount(existingMnemonic, {
    overwrite: true,
});
```

![Screenshot 2023-09-07 at 2 33 36 PM](https://github.com/rally-dfs/rly-network-mobile-sdk/assets/82558352/f5045fdd-77ee-4612-bae4-9a20354c01e1)

