### PR TITLE
Update balance methods to account for display and exact logic separation

### DIFF
--- a/src/gsnClient/EIP712/MetaTransaction.ts
+++ b/src/gsnClient/EIP712/MetaTransaction.ts
@@ -1,4 +1,4 @@
-import { ethers, Wallet } from 'ethers';
+import { BigNumber, ethers, Wallet } from 'ethers';
 import type {
   PrefixedHexString,
   GsnTransactionDetails,
@@ -97,22 +97,21 @@ export const getMetatransactionEIP712Signature = async (
 export const hasExecuteMetaTransaction = async (
   account: Wallet,
   destinationAddress: Address,
-  amount: number,
+  amount: BigNumber,
   config: NetworkConfig,
   contractAddress: Address,
   provider: ethers.providers.JsonRpcProvider
 ): Promise<boolean> => {
   try {
     const token = erc20(provider, contractAddress);
-    const [name, nonce, decimals] = await Promise.all([
+    const [name, nonce] = await Promise.all([
       token.name(),
       getSenderContractNonce(token, account.address),
       token.decimals(),
     ]);
-    const decimalAmount = ethers.utils.parseUnits(amount.toString(), decimals);
     const data = await token.interface.encodeFunctionData('transfer', [
       destinationAddress,
-      decimalAmount,
+      amount,
     ]);
 
     const { r, s, v } = await getMetatransactionEIP712Signature(
@@ -142,23 +141,21 @@ export const hasExecuteMetaTransaction = async (
 export const getExecuteMetatransactionTx = async (
   account: Wallet,
   destinationAddress: Address,
-  amount: number,
+  amount: BigNumber,
   config: NetworkConfig,
   contractAddress: string,
   provider: ethers.providers.JsonRpcProvider
 ): Promise<GsnTransactionDetails> => {
   const token = erc20(provider, contractAddress);
-  const [name, nonce, decimals] = await Promise.all([
+  const [name, nonce] = await Promise.all([
     token.name(),
     getSenderContractNonce(token, account.address),
-    token.decimals(),
   ]);
-  const decimalAmount = ethers.utils.parseUnits(amount.toString(), decimals);
 
   // get function signature
   const data = await token.interface.encodeFunctionData('transfer', [
     destinationAddress,
-    decimalAmount,
+    amount,
   ]);
 
   const { r, s, v } = await getMetatransactionEIP712Signature(

--- a/src/networks/evm_network.ts
+++ b/src/networks/evm_network.ts
@@ -44,7 +44,13 @@ async function transfer(
 
   const amountBigNum = ethers.utils.parseUnits(amount.toString(), decimals);
 
-  return await transferExact(destinationAddress, amountBigNum.toString(), network, tokenAddress, metaTxMethod);
+  return await transferExact(
+    destinationAddress,
+    amountBigNum.toString(),
+    network,
+    tokenAddress,
+    metaTxMethod
+  );
 }
 
 async function transferExact(
@@ -142,7 +148,6 @@ async function transferExact(
   return relay(transferTx, network);
 }
 
-
 // This method is deprecated. Update to 'getDisplayBalance'
 // or 'getExactBalance' instead.
 // Will be removed in future library versions.
@@ -150,7 +155,9 @@ async function getBalance(
   network: NetworkConfig,
   tokenAddress?: PrefixedHexString
 ) {
-  console.error("This method is deprecated. Update to 'getDisplayBalance' or 'getExactBalance' instead.");
+  console.error(
+    "This method is deprecated. Update to 'getDisplayBalance' or 'getExactBalance' instead."
+  );
 
   return getDisplayBalance(network, tokenAddress);
 }

--- a/src/networks/evm_network.ts
+++ b/src/networks/evm_network.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import {
   InsufficientBalanceError,
   MissingWalletError,
@@ -25,7 +25,7 @@ import { MetaTxMethod } from '../gsnClient/utils';
 
 async function transfer(
   destinationAddress: string,
-  amount: number,
+  amount: string,
   network: NetworkConfig,
   tokenAddress?: PrefixedHexString,
   metaTxMethod?: MetaTxMethod
@@ -38,11 +38,14 @@ async function transfer(
     throw MissingWalletError;
   }
 
-  const sourceBalance = await getBalance(network, tokenAddress);
+  const sourceBalance = await getExactBalance(network, tokenAddress);
 
-  const sourceFinalBalance = sourceBalance - amount;
+  const sourceBigNum = BigNumber.from(sourceBalance);
+  const amountBigNum = BigNumber.from(amount);
 
-  if (sourceFinalBalance < 0) {
+  const sourceFinalBalance = sourceBigNum.sub(amountBigNum);
+
+  if (sourceFinalBalance.lt(0)) {
     throw InsufficientBalanceError;
   }
 
@@ -59,7 +62,7 @@ async function transfer(
       transferTx = await getPermitTx(
         account,
         destinationAddress,
-        amount,
+        amountBigNum,
         network,
         tokenAddress,
         provider
@@ -68,7 +71,7 @@ async function transfer(
       transferTx = await getExecuteMetatransactionTx(
         account,
         destinationAddress,
-        amount,
+        amountBigNum,
         network,
         tokenAddress,
         provider
@@ -78,7 +81,7 @@ async function transfer(
     const executeMetaTransactionSupported = await hasExecuteMetaTransaction(
       account,
       destinationAddress,
-      amount,
+      amountBigNum,
       network,
       tokenAddress,
       provider
@@ -86,7 +89,7 @@ async function transfer(
 
     const permitSupported = await hasPermit(
       account,
-      amount,
+      amountBigNum,
       network,
       tokenAddress,
       provider
@@ -96,7 +99,7 @@ async function transfer(
       transferTx = await getExecuteMetatransactionTx(
         account,
         destinationAddress,
-        amount,
+        amountBigNum,
         network,
         tokenAddress,
         provider
@@ -105,7 +108,7 @@ async function transfer(
       transferTx = await getPermitTx(
         account,
         destinationAddress,
-        amount,
+        amountBigNum,
         network,
         tokenAddress,
         provider
@@ -117,7 +120,20 @@ async function transfer(
   return relay(transferTx, network);
 }
 
+
+// This method is deprecated. Update to 'getDisplayBalance'
+// or 'getExactBalance' instead.
+// Will be removed in future library versions.
 async function getBalance(
+  network: NetworkConfig,
+  tokenAddress?: PrefixedHexString
+) {
+  console.error("This method is deprecated. Update to 'getDisplayBalance' or 'getExactBalance' instead.");
+
+  return getDisplayBalance(network, tokenAddress);
+}
+
+async function getDisplayBalance(
   network: NetworkConfig,
   tokenAddress?: PrefixedHexString
 ) {
@@ -137,13 +153,33 @@ async function getBalance(
   return Number(ethers.utils.formatUnits(bal.toString(), decimals));
 }
 
+async function getExactBalance(
+  network: NetworkConfig,
+  tokenAddress?: PrefixedHexString
+): Promise<string> {
+  const account = await getWallet();
+
+  //if token address use it otherwise default to RLY
+  tokenAddress = tokenAddress || network.contracts.rlyERC20;
+  if (!account) {
+    throw MissingWalletError;
+  }
+
+  const provider = new ethers.providers.JsonRpcProvider(network.gsn.rpcUrl);
+
+  const token = erc20(provider, tokenAddress);
+  const bal = await token.balanceOf(account.address);
+
+  return bal.toString();
+}
+
 async function claimRly(network: NetworkConfig): Promise<string> {
   const account = await getWallet();
   if (!account) {
     throw MissingWalletError;
   }
 
-  const existingBalance = await getBalance(network);
+  const existingBalance = await getDisplayBalance(network);
 
   if (existingBalance && existingBalance > 0) {
     throw PriorDustingError;
@@ -180,7 +216,7 @@ export function getEvmNetwork(network: NetworkConfig) {
   return {
     transfer: function (
       destinationAddress: string,
-      amount: number,
+      amount: string,
       tokenAddress?: PrefixedHexString,
       metaTxMethod?: MetaTxMethod
     ) {
@@ -194,6 +230,12 @@ export function getEvmNetwork(network: NetworkConfig) {
     },
     getBalance: function (tokenAddress?: PrefixedHexString) {
       return getBalance(network, tokenAddress);
+    },
+    getDisplayBalance: function (tokenAddress?: PrefixedHexString) {
+      return getDisplayBalance(network, tokenAddress);
+    },
+    getExactBalance: function (tokenAddress?: PrefixedHexString) {
+      return getExactBalance(network, tokenAddress);
     },
     claimRly: function () {
       return claimRly(network);


### PR DESCRIPTION
There was an issue with converting balances returned from ethers into a `number`. Sometimes the rounding would be off by one wei. when attempting to transfer the max amount the on chain balance would be less causing the transfer to fail.

This updates and splits out into two methods, one for display `getDisplayBalance` which has the same functionality as the old `getBalance` (which is now marked deprecated) and `getExactBalance` which returns a string of the entire big integer balance and no decimal places.

Internal methods for gsn were updated to either take a `string` or a `BigNumber` where appropriate.