### PR TITLE
Update ethers provider to use rally protocol rpc

### DIFF
--- a/src/__tests__/integration/erc20metaTxProd.test.ts
+++ b/src/__tests__/integration/erc20metaTxProd.test.ts
@@ -5,14 +5,13 @@ import { PolygonNetworkConfig } from '../../network_config/network_config_polygo
 import * as ERC20 from '../../contracts/erc20Data.json';
 import { MetaTxMethod } from '../../gsnClient/utils';
 import { testSkipInCI } from '../__utils__/test_utils';
+import { getProvider } from '../../provider';
 
 let ethersProvider: ethers.providers.JsonRpcProvider;
 const tokenAddress = '0xd872b7fFca41a67eDA85b04A9185c6b270006b58';
 
 beforeAll(async () => {
-  ethersProvider = new ethers.providers.JsonRpcProvider(
-    PolygonNetworkConfig.gsn.rpcUrl
-  );
+  ethersProvider = getProvider(PolygonNetworkConfig);
 });
 
 // mock native code, just testing signing function

--- a/src/gsnClient/gsnClient.ts
+++ b/src/gsnClient/gsnClient.ts
@@ -17,6 +17,7 @@ import {
 } from './gsnTxHelpers';
 
 import { ethers, providers } from 'ethers';
+import { getProvider } from '../provider';
 
 interface GsnServerConfigPayload {
   relayWorkerAddress: string;
@@ -181,7 +182,7 @@ export const relayTransaction = async (
   config: NetworkConfig,
   transaction: GsnTransactionDetails
 ) => {
-  const web3Provider = new ethers.providers.JsonRpcProvider(config.gsn.rpcUrl);
+  const web3Provider = getProvider(config);
   const updatedConfig = await updateConfig(config, transaction);
   const relayRequest = await buildRelayRequest(
     updatedConfig.transaction,

--- a/src/network_config/network_config_mumbai.ts
+++ b/src/network_config/network_config_mumbai.ts
@@ -11,8 +11,7 @@ export const MumbaiNetworkConfig: NetworkConfig = {
     relayHubAddress: '0x3232f21A6E08312654270c78A773f00dd61d60f5',
     relayWorkerAddress: '0xb9950b71ec94cbb274aeb1be98e697678077a17f',
     relayUrl: 'https://api.rallyprotocol.com',
-    rpcUrl:
-      'https://polygon-mumbai.g.alchemy.com/v2/-dYNjZXvre3GC9kYtwDzzX4N8tcgomU4',
+    rpcUrl: 'https://sassy-staging.fly.dev/rpc',
     chainId: '80001',
     maxAcceptanceBudget: '285252',
     domainSeparatorName: 'GSN Relayed Transaction',

--- a/src/network_config/network_config_polygon.ts
+++ b/src/network_config/network_config_polygon.ts
@@ -11,8 +11,7 @@ export const PolygonNetworkConfig: NetworkConfig = {
     relayHubAddress: '0xfCEE9036EDc85cD5c12A9De6b267c4672Eb4bA1B',
     relayWorkerAddress: '0x579de7c56cd9a07330504a7c734023a9f703778a',
     relayUrl: 'https://api.rallyprotocol.com',
-    rpcUrl:
-      'https://polygon-mainnet.g.alchemy.com/v2/-dYNjZXvre3GC9kYtwDzzX4N8tcgomU4',
+    rpcUrl: 'https://api.rallyprotocol.com/rpc',
     chainId: '137',
     maxAcceptanceBudget: '285252',
     domainSeparatorName: 'GSN Relayed Transaction',

--- a/src/networks/evm_network.ts
+++ b/src/networks/evm_network.ts
@@ -22,6 +22,7 @@ import type {
 } from '../gsnClient/utils';
 
 import { MetaTxMethod } from '../gsnClient/utils';
+import { getProvider } from '../provider';
 
 async function transfer(
   destinationAddress: string,
@@ -30,7 +31,7 @@ async function transfer(
   tokenAddress?: PrefixedHexString,
   metaTxMethod?: MetaTxMethod
 ): Promise<string> {
-  const provider = new ethers.providers.JsonRpcProvider(network.gsn.rpcUrl);
+  const provider = getProvider(network);
 
   const account = await getWallet();
   if (!account) {
@@ -60,7 +61,7 @@ async function transferExact(
   tokenAddress?: PrefixedHexString,
   metaTxMethod?: MetaTxMethod
 ): Promise<string> {
-  const provider = new ethers.providers.JsonRpcProvider(network.gsn.rpcUrl);
+  const provider = getProvider(network);
   const account = await getWallet();
   tokenAddress = tokenAddress || network.contracts.rlyERC20;
 
@@ -168,7 +169,7 @@ async function getDisplayBalance(
 ) {
   tokenAddress = tokenAddress || network.contracts.rlyERC20;
 
-  const provider = new ethers.providers.JsonRpcProvider(network.gsn.rpcUrl);
+  const provider = getProvider(network);
   const token = erc20(provider, tokenAddress);
 
   const decimals = await token.decimals();
@@ -189,7 +190,7 @@ async function getExactBalance(
     throw MissingWalletError;
   }
 
-  const provider = new ethers.providers.JsonRpcProvider(network.gsn.rpcUrl);
+  const provider = getProvider(network);
 
   const token = erc20(provider, tokenAddress);
   const bal = await token.balanceOf(account.address);
@@ -209,7 +210,7 @@ async function claimRly(network: NetworkConfig): Promise<string> {
     throw PriorDustingError;
   }
 
-  const provider = new ethers.providers.JsonRpcProvider(network.gsn.rpcUrl);
+  const provider = getProvider(network);
 
   const claimTx = await getClaimTx(account, network, provider);
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,0 +1,22 @@
+import type { NetworkConfig } from 'src/network_config/network_config';
+
+import { providers } from 'ethers';
+import type { ConnectionInfo } from 'ethers/lib/utils';
+
+const authHeader = (config: NetworkConfig) => {
+  return {
+    Authorization: `Bearer ${config.relayerApiKey || ''}`,
+  };
+};
+
+export const getProvider = (
+  config: NetworkConfig,
+) => {
+  const connection: ConnectionInfo = {
+    headers: { ...authHeader(config) },
+    url: config.gsn.rpcUrl,
+  };
+  const provider = new providers.JsonRpcProvider(connection);
+
+  return provider;
+};


### PR DESCRIPTION
We recently started offering our own rpc endpoint that uses rally protocol api keys. This updates the ethers provider to use this endpoint and sets up a helper to generate the provider.