### PR TITLE
Migrate from Mumbai to Amoy

### DIFF
--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -14,7 +14,7 @@ import {
 import { useEffect, useState } from 'react';
 import {
   getAccountPhrase,
-  RlyMumbaiNetwork,
+  RlyAmoyNetwork,
   permanentlyDeleteAccount,
   MetaTxMethod,
   walletBackedUpToCloud,
@@ -23,7 +23,7 @@ import { RlyCard } from './components/RlyCard';
 import { LoadingModal, StandardModal } from './components/LoadingModal';
 import { PrivateConfig } from './private_config';
 
-const RlyNetwork = RlyMumbaiNetwork;
+const RlyNetwork = RlyAmoyNetwork;
 
 RlyNetwork.setApiKey(PrivateConfig.RALLY_API_KEY || '');
 
@@ -128,7 +128,7 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
                 title="View on Polygon"
                 onPress={() => {
                   Linking.openURL(
-                    `https://mumbai.polygonscan.com/address/${props.rlyAccount}`
+                    `https://www.oklink.com/amoy/address/${props.rlyAccount}`
                   );
                 }}
               />

--- a/example_expo/src/AccountOverviewScreen.tsx
+++ b/example_expo/src/AccountOverviewScreen.tsx
@@ -12,7 +12,7 @@ import {
 import { useEffect, useState } from 'react';
 import {
   getAccountPhrase,
-  RlyMumbaiNetwork,
+  RlyAmoyNetwork,
   permanentlyDeleteAccount,
   MetaTxMethod,
 } from '@rly-network/mobile-sdk';
@@ -20,7 +20,7 @@ import { RlyCard } from './components/RlyCard';
 import { LoadingModal, StandardModal } from './components/LoadingModal';
 import { PrivateConfig } from './private_config';
 
-const RlyNetwork = RlyMumbaiNetwork;
+const RlyNetwork = RlyAmoyNetwork;
 RlyNetwork.setApiKey(PrivateConfig.RALLY_API_KEY);
 
 const customTokenAddress: string | undefined = undefined;
@@ -104,7 +104,7 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
                 title="View on Polygon"
                 onPress={() => {
                   Linking.openURL(
-                    `https://mumbai.polygonscan.com/address/${props.rlyAccount}`
+                    `https://www.oklink.com/amoy/address/${props.rlyAccount}`
                   );
                 }}
               />

--- a/src/__tests__/integration/transaction.test.ts
+++ b/src/__tests__/integration/transaction.test.ts
@@ -1,6 +1,6 @@
 import { Wallet } from 'ethers';
 import { getWallet, permanentlyDeleteAccount } from '../../account';
-import { RlyMumbaiNetwork, RlyDummyNetwork } from '../../network';
+import { RlyAmoyNetwork, RlyDummyNetwork } from '../../network';
 import { testOnlyRunInCIFullSuite } from '../__utils__/test_utils';
 
 let mockMnemonic: string;
@@ -35,11 +35,11 @@ jest.mock('react-native', () => {
 testOnlyRunInCIFullSuite(
   'claim mumbai legacy method name',
   async () => {
-    RlyMumbaiNetwork.setApiKey(process.env.RALLY_PROTOCOL_MUMBAI_TOKEN!);
+    RlyAmoyNetwork.setApiKey(process.env.RALLY_PROTOCOL_MUMBAI_TOKEN!);
 
-    const oldBal = await RlyMumbaiNetwork.getBalance();
-    const txHash = await RlyMumbaiNetwork.registerAccount();
-    const newBal = await RlyMumbaiNetwork.getBalance();
+    const oldBal = await RlyAmoyNetwork.getBalance();
+    const txHash = await RlyAmoyNetwork.registerAccount();
+    const newBal = await RlyAmoyNetwork.getBalance();
     expect(oldBal).toEqual(0);
     expect(txHash).toMatch(/^0x/);
     expect(newBal).toEqual(10);
@@ -50,11 +50,11 @@ testOnlyRunInCIFullSuite(
 testOnlyRunInCIFullSuite(
   'claim mumbai',
   async () => {
-    RlyMumbaiNetwork.setApiKey(process.env.RALLY_PROTOCOL_MUMBAI_TOKEN!);
+    RlyAmoyNetwork.setApiKey(process.env.RALLY_PROTOCOL_MUMBAI_TOKEN!);
 
-    const oldBal = await RlyMumbaiNetwork.getDisplayBalance();
-    const txHash = await RlyMumbaiNetwork.claimRly();
-    const newBal = await RlyMumbaiNetwork.getDisplayBalance();
+    const oldBal = await RlyAmoyNetwork.getDisplayBalance();
+    const txHash = await RlyAmoyNetwork.claimRly();
+    const newBal = await RlyAmoyNetwork.getDisplayBalance();
 
     expect(oldBal).toEqual(0);
     expect(txHash).toMatch(/^0x/);

--- a/src/network.ts
+++ b/src/network.ts
@@ -6,7 +6,7 @@ import type {
 } from './gsnClient/utils';
 
 import {
-  MumbaiNetworkConfig,
+  AmoyNetworkConfig,
   LocalNetworkConfig,
   PolygonNetworkConfig,
   TestNetworkConfig,
@@ -37,7 +37,7 @@ export interface Network {
   setApiKey: (apiKey: string) => void;
 }
 
-export const RlyMumbaiNetwork: Network = getEvmNetwork(MumbaiNetworkConfig);
+export const RlyAmoyNetwork: Network = getEvmNetwork(AmoyNetworkConfig);
 export const RlyLocalNetwork: Network = getEvmNetwork(LocalNetworkConfig);
 export const RlyTestNetwork: Network = getEvmNetwork(TestNetworkConfig);
 export const RlyPolygonNetwork: Network = getEvmNetwork(PolygonNetworkConfig);

--- a/src/network_config/network_config.ts
+++ b/src/network_config/network_config.ts
@@ -29,5 +29,5 @@ export interface NetworkConfig {
 
 export * from './network_config_local';
 export * from './network_config_test';
-export * from './network_config_mumbai';
+export * from './network_config_amoy';
 export * from './network_config_polygon';

--- a/src/network_config/network_config_amoy.ts
+++ b/src/network_config/network_config_amoy.ts
@@ -1,18 +1,18 @@
 import type { NetworkConfig } from './network_config';
 
-export const MumbaiNetworkConfig: NetworkConfig = {
+export const AmoyNetworkConfig: NetworkConfig = {
   contracts: {
-    rlyERC20: '0x1C7312Cb60b40cF586e796FEdD60Cf243286c9E9',
-    tokenFaucet: '0xe7C3BD692C77Ec0C0bde523455B9D142c49720fF',
+    rlyERC20: '0x846d8a5fb8a003b431b67115f809a9b9fffe5012',
+    tokenFaucet: '0xb8c8274f775474f4f2549edcc4db45cbad936fac',
   },
   gsn: {
-    paymasterAddress: '0x8b3a505413Ca3B0A17F077e507aF8E3b3ad4Ce4d',
-    forwarderAddress: '0xB2b5841DBeF766d4b521221732F9B618fCf34A87',
-    relayHubAddress: '0x3232f21A6E08312654270c78A773f00dd61d60f5',
+    paymasterAddress: '0xb570b57b821670707fF4E38Ea53fcb67192278F8',
+    forwarderAddress: '0x0ae8FC9867CB4a124d7114B8bd15C4c78C4D40E5',
+    relayHubAddress: '0xe213A20A9E6CBAfd8456f9669D8a0b9e41Cb2751',
     relayWorkerAddress: '0xb9950b71ec94cbb274aeb1be98e697678077a17f',
     relayUrl: 'https://api.rallyprotocol.com',
     rpcUrl: 'https://api.rallyprotocol.com/rpc',
-    chainId: '80001',
+    chainId: '80002',
     maxAcceptanceBudget: '285252',
     domainSeparatorName: 'GSN Relayed Transaction',
     gtxDataNonZero: 16,


### PR DESCRIPTION
This is not backwards compatible as I changed the name of the network.

Amoy is too different from Mumbai to do a gracefull, backwards
compatible migration, as contract addresses have changed for anything a
dev touches on-chain. The rename of the network in our SDK makes that
much more explicit for the developer.
