### PR TITLE
Fix bug in cloud backup and properly support iCloud keychain cloud backup + sync

### DIFF
--- a/android/src/main/java/com/rlynetworkmobilesdk/MnemonicStorageHelper.kt
+++ b/android/src/main/java/com/rlynetworkmobilesdk/MnemonicStorageHelper.kt
@@ -118,14 +118,22 @@ class MnemonicStorageHelper(context: Context) {
   }
 
   fun delete(key: String) {
+    deleteFromCloudKeystore(key)
+    deleteFromSharedPref(key)
+  }
+
+  fun deleteFromCloudKeystore(key: String) {
     val retrieveRequest = DeleteBytesRequest.Builder()
-      .setKeys(listOf(key))
-      .build()
+        .setKeys(listOf(key))
+        .build()
 
     blockstoreClient.deleteBytes(retrieveRequest)
+  }
 
+  fun deleteFromSharedPref(key: String) {
     val editor = getSharedPreferences().edit()
     editor.remove(key)
     editor.commit()
   }
+
 }

--- a/android/src/main/java/com/rlynetworkmobilesdk/RlyNetworkMobileSdkModule.kt
+++ b/android/src/main/java/com/rlynetworkmobilesdk/RlyNetworkMobileSdkModule.kt
@@ -75,6 +75,12 @@ class RlyNetworkMobileSdkModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
+  fun deleteCloudMnemonic(promise:Promise){
+    mnemonicHelper.deleteFromCloudKeystore(MNEMONIC_STORAGE_KEY)
+    promise.resolve(true)
+  }
+
+  @ReactMethod
   fun getPrivateKeyFromMnemonic(mnemonic:String, promise:Promise){
     if (!MnemonicWords(mnemonic).validate(WORDLIST_ENGLISH)) {
       promise.reject("mnemonic_verification_failure", "mnemonic failed to pass check");

--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -18,6 +18,7 @@ import {
   permanentlyDeleteAccount,
   MetaTxMethod,
   walletBackedUpToCloud,
+  updateWalletStorage,
 } from '@rly-network/mobile-sdk';
 import { RlyCard } from './components/RlyCard';
 import { LoadingModal, StandardModal } from './components/LoadingModal';
@@ -57,6 +58,21 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
     fetchBalance();
     fetchCloudStatus();
   }, []);
+
+  const swapStorageLocation = async () => {
+    if (usingCloudBackup === undefined) {
+      console.log('Unable to swap location, wallet not initialized');
+      return;
+    }
+
+    const storage = {
+      saveToCloud: !usingCloudBackup,
+      rejectOnCloudSaveFailure: true,
+    };
+    await updateWalletStorage(storage);
+
+    await fetchCloudStatus();
+  };
 
   const claimRlyTokens = async () => {
     setPerformingAction('Registering Account');
@@ -176,6 +192,16 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
               <BodyText>Export Your Account</BodyText>
             </View>
             <Button title="Reveal my Mnemonic" onPress={revealMnemonic} />
+          </RlyCard>
+
+          <RlyCard style={styles.balanceCard}>
+            <View style={styles.alignMiddle}>
+              <BodyText>Change wallet storage</BodyText>
+            </View>
+            <Button
+              title="Swap Storage Location"
+              onPress={swapStorageLocation}
+            />
           </RlyCard>
 
           <RlyCard style={styles.balanceCard}>

--- a/ios/KeychainHelper.swift
+++ b/ios/KeychainHelper.swift
@@ -1,22 +1,66 @@
 import Foundation
 
 final class KeychainHelper {
-    
     static let standard = KeychainHelper()
     private init() {}
-    
+
     func save(
       _ data: Data,
       service: String,
       account: String,
       saveToCloud: Bool
     ) {
+        if (saveToCloud) {
+            saveToiCloudKeychain(data, service: service, account: account)
+        } else {
+            saveToDeviceKeychain(data, service: service, account: account)
+        }
+    }
+
+    func saveToiCloudKeychain(
+      _ data: Data,
+      service: String,
+      account: String
+    ) {
+        let query = [
+            kSecValueData: data,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecAttrSynchronizable: true,
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
+        ] as CFDictionary
+
+        // Add data in query to keychain
+        let status = SecItemAdd(query, nil)
+
+        if status == errSecDuplicateItem {
+            // Item already exist, thus update it.
+            let query = [
+                kSecAttrService: service,
+                kSecAttrAccount: account,
+                kSecAttrSynchronizable: true,
+                kSecClass: kSecClassGenericPassword,
+            ] as CFDictionary
+
+            let attributesToUpdate = [kSecValueData: data] as CFDictionary
+
+            // Update existing item
+            SecItemUpdate(query, attributesToUpdate)
+        }
+    }
+
+    func saveToDeviceKeychain(
+      _ data: Data,
+      service: String,
+      account: String
+    ) {
         let query = [
             kSecValueData: data,
             kSecAttrService: service,
             kSecAttrAccount: account,
             kSecClass: kSecClassGenericPassword,
-            kSecAttrAccessible: saveToCloud ? kSecAttrAccessibleWhenUnlocked : kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
         ] as CFDictionary
 
         // Add data in query to keychain
@@ -37,7 +81,7 @@ final class KeychainHelper {
         }
     }
 
-    func readAttributes(service: String, account: String) -> [String: Any]? {
+    func readDeviceKeychainAttributes(service: String, account: String) -> [String: Any]? {
         let query = [
             kSecAttrService: service,
             kSecAttrAccount: account,
@@ -51,29 +95,98 @@ final class KeychainHelper {
         return (result as? [String: Any])
     }
 
+    func shouldMigrateToiCloudKeychain(service: String, account: String) -> Bool {
+        let readResult = readDeviceKeychainAttributes(service: service, account: account)
+
+        if (readResult == nil) {
+            return false
+        }
+
+        let keyAccessibility = readResult?[kSecAttrAccessible as String] as? String
+
+        // This will return true when the following conditions are met
+        // Data is found
+        // Data is saved with    kSecAttrSynchronizable: false
+        // Data is saved with    kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
+        // These conditions are met with data intended to be saved to cloud on iOS
+        // with RLY SDK versions prior to this fix
+
+        return keyAccessibility == (kSecAttrAccessibleWhenUnlocked as String)
+    }
+
+
     func read(service: String, account: String) -> Data? {
-        
+        let iCloudData = readFromiCloudKeychain(service: service, account: account) ;
+
+        if (iCloudData != nil) {
+            return iCloudData
+        }
+
+        let localData = readFromDeviceKeychain(service: service, account: account)
+
+        // Auto migrate data to iCloud Keychain when appropriate conditions are met
+        if (localData != nil && shouldMigrateToiCloudKeychain(service: service, account: account)) {
+            saveToiCloudKeychain(localData!, service: service, account: account)
+        }
+
+        return localData
+    }
+
+    func readFromDeviceKeychain(service: String, account: String) -> Data? {
         let query = [
             kSecAttrService: service,
             kSecAttrAccount: account,
             kSecClass: kSecClassGenericPassword,
-            kSecReturnData: true
+            kSecReturnData: true,
         ] as CFDictionary
-        
+
         var result: AnyObject?
-        SecItemCopyMatching(query, &result)
-        
+        let status = withUnsafeMutablePointer(to: &result) {
+            SecItemCopyMatching(query, UnsafeMutablePointer($0))
+        }
+
         return (result as? Data)
     }
-    
+
+    func readFromiCloudKeychain(service: String, account: String) -> Data? {
+        let query = [
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecAttrSynchronizable: true,
+            kSecClass: kSecClassGenericPassword,
+            kSecReturnData: true,
+        ] as CFDictionary
+
+        var result: AnyObject?
+        SecItemCopyMatching(query, &result)
+
+        return (result as? Data)
+    }
+
     func delete(service: String, account: String) {
-        
+        deleteFromDeviceKeychain(service: service, account: account)
+        deleteFromiCloudKeychain(service: service, account: account)
+    }
+
+    func deleteFromDeviceKeychain(service: String, account: String) {
         let query = [
             kSecAttrService: service,
             kSecAttrAccount: account,
             kSecClass: kSecClassGenericPassword,
             ] as CFDictionary
-        
+
+        // Delete item from keychain
+        SecItemDelete(query)
+    }
+
+    func deleteFromiCloudKeychain(service: String, account: String) {
+        let query = [
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecAttrSynchronizable: true,
+            kSecClass: kSecClassGenericPassword,
+            ] as CFDictionary
+
         // Delete item from keychain
         SecItemDelete(query)
     }

--- a/ios/KeychainHelper.swift
+++ b/ios/KeychainHelper.swift
@@ -81,40 +81,6 @@ final class KeychainHelper {
         }
     }
 
-    func readDeviceKeychainAttributes(service: String, account: String) -> [String: Any]? {
-        let query = [
-            kSecAttrService: service,
-            kSecAttrAccount: account,
-            kSecClass: kSecClassGenericPassword,
-            kSecReturnAttributes: true
-        ] as CFDictionary
-
-        var result: AnyObject?
-        SecItemCopyMatching(query, &result)
-
-        return (result as? [String: Any])
-    }
-
-    func shouldMigrateToiCloudKeychain(service: String, account: String) -> Bool {
-        let readResult = readDeviceKeychainAttributes(service: service, account: account)
-
-        if (readResult == nil) {
-            return false
-        }
-
-        let keyAccessibility = readResult?[kSecAttrAccessible as String] as? String
-
-        // This will return true when the following conditions are met
-        // Data is found
-        // Data is saved with    kSecAttrSynchronizable: false
-        // Data is saved with    kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
-        // These conditions are met with data intended to be saved to cloud on iOS
-        // with RLY SDK versions prior to this fix
-
-        return keyAccessibility == (kSecAttrAccessibleWhenUnlocked as String)
-    }
-
-
     func read(service: String, account: String) -> Data? {
         let iCloudData = readFromiCloudKeychain(service: service, account: account) ;
 

--- a/ios/KeychainHelper.swift
+++ b/ios/KeychainHelper.swift
@@ -5,12 +5,12 @@ final class KeychainHelper {
     private init() {}
 
     func save(
-      _ data: Data,
-      service: String,
-      account: String,
-      saveToCloud: Bool
+        _ data: Data,
+        service: String,
+        account: String,
+        saveToCloud: Bool
     ) {
-        if (saveToCloud) {
+        if saveToCloud {
             saveToiCloudKeychain(data, service: service, account: account)
         } else {
             saveToDeviceKeychain(data, service: service, account: account)
@@ -18,9 +18,9 @@ final class KeychainHelper {
     }
 
     func saveToiCloudKeychain(
-      _ data: Data,
-      service: String,
-      account: String
+        _ data: Data,
+        service: String,
+        account: String
     ) {
         let query = [
             kSecValueData: data,
@@ -51,9 +51,9 @@ final class KeychainHelper {
     }
 
     func saveToDeviceKeychain(
-      _ data: Data,
-      service: String,
-      account: String
+        _ data: Data,
+        service: String,
+        account: String
     ) {
         let query = [
             kSecValueData: data,
@@ -82,9 +82,9 @@ final class KeychainHelper {
     }
 
     func read(service: String, account: String) -> Data? {
-        let iCloudData = readFromiCloudKeychain(service: service, account: account) ;
+        let iCloudData = readFromiCloudKeychain(service: service, account: account)
 
-        if (iCloudData != nil) {
+        if iCloudData != nil {
             return iCloudData
         }
 
@@ -132,7 +132,7 @@ final class KeychainHelper {
             kSecAttrService: service,
             kSecAttrAccount: account,
             kSecClass: kSecClassGenericPassword,
-            ] as CFDictionary
+        ] as CFDictionary
 
         // Delete item from keychain
         SecItemDelete(query)
@@ -144,7 +144,7 @@ final class KeychainHelper {
             kSecAttrAccount: account,
             kSecAttrSynchronizable: true,
             kSecClass: kSecClassGenericPassword,
-            ] as CFDictionary
+        ] as CFDictionary
 
         // Delete item from keychain
         SecItemDelete(query)

--- a/ios/KeychainHelper.swift
+++ b/ios/KeychainHelper.swift
@@ -124,11 +124,6 @@ final class KeychainHelper {
 
         let localData = readFromDeviceKeychain(service: service, account: account)
 
-        // Auto migrate data to iCloud Keychain when appropriate conditions are met
-        if (localData != nil && shouldMigrateToiCloudKeychain(service: service, account: account)) {
-            saveToiCloudKeychain(localData!, service: service, account: account)
-        }
-
         return localData
     }
 

--- a/ios/KeychainHelper.swift
+++ b/ios/KeychainHelper.swift
@@ -141,9 +141,7 @@ final class KeychainHelper {
         ] as CFDictionary
 
         var result: AnyObject?
-        let status = withUnsafeMutablePointer(to: &result) {
-            SecItemCopyMatching(query, UnsafeMutablePointer($0))
-        }
+        SecItemCopyMatching(query, &result)
 
         return (result as? Data)
     }

--- a/ios/RlyNetworkMobileSdk.m
+++ b/ios/RlyNetworkMobileSdk.m
@@ -42,6 +42,11 @@ RCT_EXTERN_METHOD(deleteMnemonic:
     rejecter: (RCTPromiseRejectBlock) reject
 )
 
+RCT_EXTERN_METHOD(deleteCloudMnemonic:
+    (RCTPromiseResolveBlock) resolve
+    rejecter: (RCTPromiseRejectBlock) reject
+)
+
 
 RCT_EXTERN_METHOD(getPrivateKeyFromMnemonic:
     (NSString) mnemonic

--- a/ios/RlyNetworkMobileSdk.swift
+++ b/ios/RlyNetworkMobileSdk.swift
@@ -83,6 +83,21 @@ class RlyNetworkMobileSdk: NSObject {
         resolve(true)
     }
 
+
+    /*
+    * Necessary for RN level logic that allows dev to migrate key from cloud storage to device storage
+    * For now there is no need for a delete of the local only version since that risks complete key loss,
+    * and having an extra copy scoped to device only when dev asks for cloud is not a security risk.
+    */
+    @objc public func deleteCloudMnemonic(
+      _ resolve: RCTPromiseResolveBlock,
+      rejecter reject: RCTPromiseRejectBlock
+    ) -> Void {
+        KeychainHelper.standard.deleteFromiCloudKeychain(service: SERVICE_KEY, account: MNEMONIC_ACCOUNT_KEY)
+
+        resolve(true)
+    }
+
     @objc public func getPrivateKeyFromMnemonic(
       _ mnemonic: String,
       resolver resolve: RCTPromiseResolveBlock,

--- a/src/__tests__/account.test.ts
+++ b/src/__tests__/account.test.ts
@@ -7,7 +7,7 @@ import {
   signTransaction,
   signHash,
 } from '../account';
-import type { KeyStorageConfig } from 'src/keyManagerTypes';
+import type { KeyStorageConfig } from 'src/key_storage_config';
 
 // mock native code, just testing signing function
 // address is 0x88046468228953d17c7DAaE39cfEF9B4b082164D, pk is 0x8666ebf0f4d397955c55932642fb9dd97fb60a2df121a9d2a39f7f1930958ca3)

--- a/src/account.ts
+++ b/src/account.ts
@@ -127,7 +127,31 @@ export async function getWallet() {
   return wallet;
 }
 
+/**
+ * @deprecated This method is deprecated and will be removed in a future version. Use `walletEligibleForCloudSync` instead.
+ * The naming of this method was confusing and has been deprecated in favor of walletEligibleForCloudSync.
+ * Name implied a level of control over device syncing that is not possible given the operating system constraints. See walletEligibleForCloudSync for more details.
+ */
 export async function walletBackedUpToCloud() {
+  return await KeyManager.walletBackedUpToCloud();
+}
+
+/**
+ * Determines if the current wallet is eligible for OS-provided cloud backup and cross-device sync.
+ *
+ * @returns `true` if the wallet is stored in a way that makes it eligible for cloud backup and sync, `false` otherwise.
+ *
+ * @remarks
+ * This does NOT guarantee that the wallet is actively backed up. It simply indicates eligibility.
+ * Actual cloud backup depends on user and app-level settings for secure key storage.
+ *
+ * - **iOS:** Checks if the wallet will sync when iCloud Keychain sync is enabled.
+ * - **Android:** Checks if the wallet is in Google Play Keystore and will sync when Google backup is enabled.
+ *
+ * **Important Note:**
+ * Do NOT use this method to check for wallet existence. It will return `false` if no wallet is found OR if the wallet exists but isn't configured for cloud backup.
+ */
+export async function walletEligibleForCloudSync() {
   return await KeyManager.walletBackedUpToCloud();
 }
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -86,12 +86,12 @@ async function _saveAccount(
  * - **Device-Only Transition:** When moving from cloud to device-only storage, the wallet will be removed from cloud storage and any other devices.
  */
 export async function updateWalletStorage(storageOptions: KeyStorageConfig) {
-  const wallet = await getWallet();
-  if (!wallet) {
+  const mnemonic = await getAccountPhrase();
+  if (!mnemonic) {
     throw new Error('Can not update storage, no wallet found');
   }
 
-  await KeyManager.saveMnemonic(wallet.mnemonic.phrase, storageOptions);
+  await KeyManager.saveMnemonic(mnemonic, storageOptions);
 
   if (!storageOptions.saveToCloud) {
     await KeyManager.deleteCloudMnemonic();

--- a/src/account.ts
+++ b/src/account.ts
@@ -68,6 +68,36 @@ async function _saveAccount(
   return newWallet.address;
 }
 
+/**
+ * Updates the storage settings for an existing wallet.
+ *
+ * @param config A `KeyStorageConfig` object to specify the storage options for the wallet.
+ *
+ * @throws Throws an error if no wallet is found.
+ * @rejects Rejects the promise if cloud save fails and `rejectOnCloudSaveFailure` is set to `true`.
+ * @remarks
+ * If `rejectOnCloudSaveFailure` is `false`, cloud save failure will fallback to on-device-only storage without rejecting.
+ *
+ * **Important Considerations:**
+ *
+ * - **Cloud Transition:**  When moving from `KeyStorageConfig.saveToCloud = false` to `true`, the wallet will be moved to device cloud,
+ *  potentially replacing a non-cloud wallet on other devices.
+ *  Ensure users are aware of this potential for overwriting data.
+ * - **Device-Only Transition:** When moving from cloud to device-only storage, the wallet will be removed from cloud storage and any other devices.
+ */
+export async function updateWalletStorage(storageOptions: KeyStorageConfig) {
+  const wallet = await getWallet();
+  if (!wallet) {
+    throw new Error('Can not update storage, no wallet found');
+  }
+
+  await KeyManager.saveMnemonic(wallet.mnemonic.phrase, storageOptions);
+
+  if (!storageOptions.saveToCloud) {
+    await KeyManager.deleteCloudMnemonic();
+  }
+}
+
 export async function createAccount(options: CreateAccountOptions = {}) {
   return await _saveAccount(KeyManager.generateMnemonic(), options);
 }

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,7 +1,7 @@
 import { Wallet, utils, BigNumber } from 'ethers';
 import type { TypedDataDomain, TypedDataField } from 'ethers';
 import KeyManager from './keyManager';
-import type { KeyStorageConfig } from './keyManagerTypes';
+import type { KeyStorageConfig } from './key_storage_config';
 
 let _cachedWallet: Wallet | undefined;
 

--- a/src/keyManagerExpo.ts
+++ b/src/keyManagerExpo.ts
@@ -1,5 +1,5 @@
 import { utils, Wallet } from 'ethers';
-import type { KeyStorageConfig } from './keyManagerTypes';
+import type { KeyStorageConfig } from './key_storage_config';
 
 type ExpoObject = {
   modules: undefined | { [key: string]: any };

--- a/src/keyManagerNativeModule.ts
+++ b/src/keyManagerNativeModule.ts
@@ -50,6 +50,10 @@ export const deleteMnemonic = async (): Promise<void> => {
   return RlyNativeModule.deleteMnemonic();
 };
 
+export const deleteCloudMnemonic = async (): Promise<void> => {
+  return RlyNativeModule.deleteCloudMnemonic();
+};
+
 export const getPrivateKeyFromMnemonic = async (
   mnemonic: string
 ): Promise<Uint8Array> => {

--- a/src/keyManagerNativeModule.ts
+++ b/src/keyManagerNativeModule.ts
@@ -1,5 +1,5 @@
 import { NativeModules, Platform } from 'react-native';
-import type { KeyStorageConfig } from './keyManagerTypes';
+import type { KeyStorageConfig } from './key_storage_config';
 
 const LINKING_ERROR =
   `The package 'rly-network-mobile-sdk' doesn't seem to be linked. Make sure: \n\n` +

--- a/src/keyManagerTypes.ts
+++ b/src/keyManagerTypes.ts
@@ -1,7 +1,4 @@
-export type KeyStorageConfig = {
-  saveToCloud: boolean;
-  rejectOnCloudSaveFailure: boolean;
-};
+import type { KeyStorageConfig } from './key_storage_config';
 
 export interface KeyManager {
   getMnemonic: () => Promise<string | null>;

--- a/src/keyManagerTypes.ts
+++ b/src/keyManagerTypes.ts
@@ -6,6 +6,7 @@ export interface KeyManager {
   generateMnemonic: () => Promise<string>;
   saveMnemonic: (mnemonic: string, options?: KeyStorageConfig) => Promise<void>;
   deleteMnemonic: () => Promise<void>;
+  deleteCloudMnemonic: () => Promise<void>;
   getPrivateKeyFromMnemonic: (mnemonic: string) => Promise<Uint8Array>;
 }
 

--- a/src/key_storage_config.ts
+++ b/src/key_storage_config.ts
@@ -1,0 +1,24 @@
+/**
+ * Configuration for how the wallet key should be stored. This includes whether to save to cloud and whether to reject if saving to cloud fails.
+ *
+ * @param saveToCloud Whether to save the mnemonic in a way that is eligible for device OS cloud storage.
+ *   If set to `false`, the mnemonic will only be stored on device.
+ *
+ * @param rejectOnCloudSaveFailure Whether to raise an error if saving to cloud fails.
+ *   If set to `false`, the mnemonic will silently fall back to local on-device-only storage.
+ *
+ * @remarks
+ * Please note that when transitioning `KeyStorageConfig.saveToCloud` from `false` to `true`, the wallet will be moved to cross-device sync.
+ * This can overwrite a device-only wallet your user might have on a different device. Ensure you properly communicate to end users
+ * that moving to cloud storage could cause issues if they currently have different wallets on different devices.
+ *
+ * **Important Considerations for `saveToCloud`:**
+ *
+ * 1. Keys are stored using the OS-provided cross-device backup mechanism. This mechanism is controlled by user and app preferences and can be disabled.
+ * 2. On Android, the backup mechanism is Blockstore, requiring the user to be logged into their Play account and have a device PIN code or password set.
+ * 3. On iOS, the backup mechanism is iCloud Keychain, requiring the user to be logged into iCloud and have iCloud backup enabled.
+ */
+export interface KeyStorageConfig {
+  saveToCloud: boolean;
+  rejectOnCloudSaveFailure: boolean;
+}


### PR DESCRIPTION
This addresses the issue where the cloud sync status returned by `walletBackedUpToCloud` on iOS was returning inaccurate & misleading response. We are now more correctly setting our iOS keychain storage flags for real cloud sync.

Migrating from device only storage to cloud sync storage comes with some end user risk if users have multiple wallets on different devices. Therefore, there is no auto migration of data. Instead we have exposed a method through WalletManager that allows developers to update the storage config of an existing wallet.

* Update iOS key management to save to iCloud cross device keychain
* Deprecate old method and replace with more accurately named method for checking cloud sync eligibility 
* Add method to update the storage settings on existing wallets