### PR TITLE
Short term fix to swapping mnemonic storage location in example app

### DIFF
--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -65,9 +65,11 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
       return;
     }
 
+    const changeToCloud = !usingCloudBackup;
+
     const storage = {
-      saveToCloud: !usingCloudBackup,
-      rejectOnCloudSaveFailure: true,
+      saveToCloud: changeToCloud,
+      rejectOnCloudSaveFailure: changeToCloud,
     };
     await updateWalletStorage(storage);
 


### PR DESCRIPTION
The naïve implementation of the swapping of storage in the example app
uncovered an interested devex edge case where Android native code throws
a confusing error message is a user asks for `saveToCloud: false` and
`rejectOnCloudSaveFailure: true`.

This works around that confusion by making sure those 2 flags are
aligned at the point of calling in example app.

Longer term we should fix the devex of the core SDK.
