### PR TITLE
Add base mainnet config

### DIFF
--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -15,13 +15,11 @@ import { useEffect, useState } from 'react';
 import {
   getAccountPhrase,
   RlyBaseSepoliaNetwork,
-  RlyBaseNetwork,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   RlyAmoyNetwork,
   permanentlyDeleteAccount,
-  MetaTxMethod,
   walletBackedUpToCloud,
   updateWalletStorage,
+  TokenConfig,
 } from '@rly-network/mobile-sdk';
 import { RlyCard } from './components/RlyCard';
 import { LoadingModal, StandardModal } from './components/LoadingModal';
@@ -31,8 +29,10 @@ const RlyNetwork = RlyAmoyNetwork;
 
 RlyNetwork.setApiKey(PrivateConfig.RALLY_API_KEY || '');
 
-// If you want to test using a custom token, set the hex address of the token here
-const tokenTransactionType: MetaTxMethod = MetaTxMethod.Permit;
+// If you want to test using a custom token, you need to build the object by hand.
+// You can find a list of pre-built supported tokens in supported_tokens.
+// If no value is provided, the default token is RLY
+const customToken: TokenConfig | undefined = undefined;
 
 export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
   const [performingAction, setPerformingAction] = useState<string>();
@@ -46,7 +46,7 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
   const [mnemonic, setMnemonic] = useState<string>();
 
   const fetchBalance = async () => {
-    const bal = await RlyNetwork.getDisplayBalance(customTokenAddress);
+    const bal = await RlyNetwork.getDisplayBalance(customToken?.address);
 
     setBalance(bal);
   };
@@ -97,8 +97,9 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
       await RlyNetwork.transfer(
         transferAddress,
         parseInt(transferBalance, 10),
-        customTokenAddress,
-        tokenTransactionType
+        customToken?.address,
+        customToken?.metaTxnMethod,
+        customToken
       );
       await fetchBalance();
       setTransferBalance('');

--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -15,6 +15,8 @@ import { useEffect, useState } from 'react';
 import {
   getAccountPhrase,
   RlyBaseSepoliaNetwork,
+  RlyBaseNetwork,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   RlyAmoyNetwork,
   permanentlyDeleteAccount,
   MetaTxMethod,
@@ -30,7 +32,7 @@ const RlyNetwork = RlyAmoyNetwork;
 RlyNetwork.setApiKey(PrivateConfig.RALLY_API_KEY || '');
 
 // If you want to test using a custom token, set the hex address of the token here
-const customTokenAddress: string | undefined = undefined;
+const tokenTransactionType: MetaTxMethod = MetaTxMethod.Permit;
 
 export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
   const [performingAction, setPerformingAction] = useState<string>();
@@ -96,12 +98,13 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
         transferAddress,
         parseInt(transferBalance, 10),
         customTokenAddress,
-        MetaTxMethod.ExecuteMetaTransaction
+        tokenTransactionType
       );
       await fetchBalance();
       setTransferBalance('');
       setTranferAddress('');
     } catch (e: any) {
+      console.log('Something went wrong', e.message);
       Alert.alert('Something went wrong', e.message);
     } finally {
       setPerformingAction(undefined);

--- a/src/gsnClient/EIP712/typedSigning.ts
+++ b/src/gsnClient/EIP712/typedSigning.ts
@@ -74,6 +74,7 @@ export interface EIP712Domain {
   version?: string;
   chainId?: number;
   verifyingContract?: string;
+  salt?: string;
 }
 
 export class TypedGsnRequestData {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,3 +4,4 @@ import '@ethersproject/shims';
 export * from './account';
 export { MetaTxMethod } from './gsnClient/utils';
 export * from './network';
+export * from './transactions/supported_tokens';

--- a/src/network.ts
+++ b/src/network.ts
@@ -13,6 +13,7 @@ import {
   NetworkConfig,
 } from './network_config/network_config';
 import { BaseSepoliaNetworkConfig } from './network_config/network_config_base_sepolia';
+import { BaseNetworkConfig } from './network_config/network_config_base';
 
 export interface Network {
   networkConfig: NetworkConfig;
@@ -42,6 +43,7 @@ export const RlyAmoyNetwork: Network = getEvmNetwork(AmoyNetworkConfig);
 export const RlyBaseSepoliaNetwork: Network = getEvmNetwork(
   BaseSepoliaNetworkConfig
 );
+export const RlyBaseNetwork: Network = getEvmNetwork(BaseNetworkConfig);
 export const RlyLocalNetwork: Network = getEvmNetwork(LocalNetworkConfig);
 export const RlyTestNetwork: Network = getEvmNetwork(TestNetworkConfig);
 export const RlyPolygonNetwork: Network = getEvmNetwork(PolygonNetworkConfig);

--- a/src/network_config/network_config_base.ts
+++ b/src/network_config/network_config_base.ts
@@ -1,0 +1,26 @@
+import type { NetworkConfig } from './network_config';
+
+export const BaseNetworkConfig: NetworkConfig = {
+  contracts: {
+    //TODO: there are no contracts for base mainnet. Client needs update to handle this case gracefully.
+    rlyERC20: '0x000',
+    tokenFaucet: '0x000',
+  },
+  gsn: {
+    paymasterAddress: '0x01B83B33F0DD8be68627a9BE68E9e7E3c209a6b1',
+    forwarderAddress: '0x524266345fB331cb624E27D2Cf5B61E769527FCC',
+    relayHubAddress: '0x54623092d2dB00D706e0Ad4ADaCc024F9cB9E915',
+    relayWorkerAddress: '0x7c5b7cf606ab2b56ead90b583bad47c5fd2c3417',
+    relayUrl: 'https://api.rallyprotocol.com',
+    rpcUrl: 'https://api.rallyprotocol.com/rpc',
+    chainId: '8453',
+    maxAcceptanceBudget: '285252',
+    domainSeparatorName: 'GSN Relayed Transaction',
+    gtxDataNonZero: 16,
+    gtxDataZero: 4,
+    requestValidSeconds: 172800,
+    maxPaymasterDataLength: 300,
+    maxApprovalDataLength: 300,
+    maxRelayNonceGap: 3,
+  },
+};

--- a/src/networks/evm_network.ts
+++ b/src/networks/evm_network.ts
@@ -23,13 +23,15 @@ import type {
 
 import { MetaTxMethod } from '../gsnClient/utils';
 import { getProvider } from '../provider';
+import type { TokenConfig } from 'src/transactions/supported_tokens';
 
 async function transfer(
   destinationAddress: string,
   amount: number,
   network: NetworkConfig,
   tokenAddress?: PrefixedHexString,
-  metaTxMethod?: MetaTxMethod
+  metaTxMethod?: MetaTxMethod,
+  tokenConfig?: TokenConfig
 ): Promise<string> {
   const provider = getProvider(network);
 
@@ -50,7 +52,8 @@ async function transfer(
     amountBigNum.toString(),
     network,
     tokenAddress,
-    metaTxMethod
+    metaTxMethod,
+    tokenConfig
   );
 }
 
@@ -59,7 +62,8 @@ async function transferExact(
   amount: string,
   network: NetworkConfig,
   tokenAddress?: PrefixedHexString,
-  metaTxMethod?: MetaTxMethod
+  metaTxMethod?: MetaTxMethod,
+  tokenConfig?: TokenConfig
 ): Promise<string> {
   const provider = getProvider(network);
   const account = await getWallet();
@@ -94,7 +98,8 @@ async function transferExact(
         amountBigNum,
         network,
         tokenAddress,
-        provider
+        provider,
+        tokenConfig?.eip712Domain
       );
     } else {
       transferTx = await getExecuteMetatransactionTx(

--- a/src/transactions/supported_tokens.ts
+++ b/src/transactions/supported_tokens.ts
@@ -1,0 +1,49 @@
+import type { EIP712Domain } from '../gsnClient/EIP712/typedSigning';
+import { MetaTxMethod } from '../gsnClient/utils';
+
+/*
+ * TokenConfig is a configuration object that is used to define the properties of a token.
+ * address: The address of the token contract.
+ * metaTxnMethod: The method of meta transaction that the token supports. See MetaTxMethod for more information.
+ * This is most likely going to be MetaTxMethod.Permit.
+ * eip712Domain: The EIP712 domain object for the token. This is only required if the token uses non default values for EIP712 signature generation.
+ */
+export interface TokenConfig {
+  address: string;
+  metaTxnMethod: MetaTxMethod;
+  eip712Domain?: EIP712Domain;
+}
+
+/*
+ * Pre built configuration for USDC on Base Mainnet
+ */
+export const BaseUSDC: TokenConfig = {
+  address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  metaTxnMethod: MetaTxMethod.Permit,
+  eip712Domain: {
+    version: '2',
+  },
+};
+
+/*
+ * Pre built configuration for RLY on Sepolia Base.
+ * This is the token this SDK tests with by default.
+ */
+export const BaseSepoliaRLY: TokenConfig = {
+  address: '0x846D8a5fb8a003b431b67115f809a9B9FFFe5012',
+  metaTxnMethod: MetaTxMethod.Permit,
+  eip712Domain: {
+    version: '1',
+  },
+};
+
+/*
+ * This is a custom version of RLY configured to support
+ * the executeMetaTransaction style of meta transactions.
+ * Should only be used for specific testing purposes. If you aren't sure
+ * whether you need MetaTxMethod.ExecuteMetaTransaction, you probably don't.
+ */
+export const BaseSepoliaExecMetaRLY: TokenConfig = {
+  address: '0x16723e9bb894EfC09449994eC5bCF5b41EE0D9b2',
+  metaTxnMethod: MetaTxMethod.ExecuteMetaTransaction,
+};


### PR DESCRIPTION
For now this config uses a dummy / junk value for the RLY token and
faucet address. The core client needs to be updated to handle this
gracefully, but that is beyond the scope of getting started on base
mainnet
