### PR TITLE
More explicit determination of how to get nonce for transfer txns

### DIFF
--- a/src/gsnClient/EIP712/MetaTransaction.ts
+++ b/src/gsnClient/EIP712/MetaTransaction.ts
@@ -1,8 +1,9 @@
 import { BigNumber, ethers, Wallet } from 'ethers';
-import type {
-  PrefixedHexString,
-  GsnTransactionDetails,
-  Address,
+import {
+  type PrefixedHexString,
+  type GsnTransactionDetails,
+  type Address,
+  MetaTxMethod,
 } from '../utils';
 import { erc20 } from '../../contract';
 import type { NetworkConfig } from '../../network_config/network_config';
@@ -105,7 +106,11 @@ export const hasExecuteMetaTransaction = async (
   try {
     const token = erc20(provider, contractAddress);
     const name = await token.name();
-    const nonce = await getSenderContractNonce(token, account.address);
+    const nonce = await getSenderContractNonce(
+      token,
+      account.address,
+      MetaTxMethod.ExecuteMetaTransaction
+    );
 
     const data = token.interface.encodeFunctionData('transfer', [
       destinationAddress,
@@ -146,7 +151,11 @@ export const getExecuteMetatransactionTx = async (
 ): Promise<GsnTransactionDetails> => {
   const token = erc20(provider, contractAddress);
   const name = await token.name();
-  const nonce = await getSenderContractNonce(token, account.address);
+  const nonce = await getSenderContractNonce(
+    token,
+    account.address,
+    MetaTxMethod.ExecuteMetaTransaction
+  );
 
   // get function signature
   const data = token.interface.encodeFunctionData('transfer', [

--- a/src/gsnClient/EIP712/PermitTransaction.ts
+++ b/src/gsnClient/EIP712/PermitTransaction.ts
@@ -1,8 +1,9 @@
 import { ethers, Wallet, BigNumber } from 'ethers';
-import type {
-  PrefixedHexString,
-  GsnTransactionDetails,
-  Address,
+import {
+  type PrefixedHexString,
+  type GsnTransactionDetails,
+  type Address,
+  MetaTxMethod,
 } from '../utils';
 import { erc20 } from '../../contract';
 import type { NetworkConfig } from '../../network_config/network_config';
@@ -112,7 +113,11 @@ export const hasPermit = async (
     const token = erc20(provider, contractAddress);
 
     const name = await token.name();
-    const nonce = await getSenderContractNonce(token, account.address);
+    const nonce = await getSenderContractNonce(
+      token,
+      account.address,
+      MetaTxMethod.Permit
+    );
     const deadline = await getPermitDeadline(provider);
     const eip712Domain = await token.eip712Domain();
 
@@ -156,10 +161,13 @@ export const getPermitTx = async (
   const token = erc20(provider, contractAddress);
 
   const name = await token.name();
-  const nonce = await getSenderContractNonce(token, account.address);
+  const nonce = await getSenderContractNonce(
+    token,
+    account.address,
+    MetaTxMethod.Permit
+  );
   const deadline = await getPermitDeadline(provider);
   const eip712Domain = await token.eip712Domain();
-
   const { salt } = eip712Domain;
 
   const { r, s, v } = await getPermitEIP712Signature(


### PR DESCRIPTION
No more trying to fetch the bytecode and then match on a specific byte
sequence in the bytecode to determine if we should use nonces or
getNonce. Now that is just an explicit param based on the type of meta
txn since `nonces` is part of the permit spec
