### PR TITLE
Begin to expose new way of configuring token transfers

### DIFF
--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -19,20 +19,24 @@ import {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   RlyAmoyNetwork,
   permanentlyDeleteAccount,
-  MetaTxMethod,
   walletBackedUpToCloud,
   updateWalletStorage,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  BaseUSDC,
+  TokenConfig,
 } from '@rly-network/mobile-sdk';
 import { RlyCard } from './components/RlyCard';
 import { LoadingModal, StandardModal } from './components/LoadingModal';
 import { PrivateConfig } from './private_config';
 
-const RlyNetwork = RlyAmoyNetwork;
+const RlyNetwork = RlyBaseNetwork;
 
 RlyNetwork.setApiKey(PrivateConfig.RALLY_API_KEY || '');
 
-// If you want to test using a custom token, set the hex address of the token here
-const tokenTransactionType: MetaTxMethod = MetaTxMethod.Permit;
+// If you want to test using a custom token, you need to build the object by hand.
+// You can find a list of pre-built supported tokens in supported_tokens.
+// If no value is provided, the default token is RLY
+const customToken: TokenConfig | undefined = undefined;
 
 export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
   const [performingAction, setPerformingAction] = useState<string>();
@@ -46,7 +50,7 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
   const [mnemonic, setMnemonic] = useState<string>();
 
   const fetchBalance = async () => {
-    const bal = await RlyNetwork.getDisplayBalance(customTokenAddress);
+    const bal = await RlyNetwork.getDisplayBalance(customToken?.address);
 
     setBalance(bal);
   };
@@ -97,8 +101,9 @@ export const AccountOverviewScreen = (props: { rlyAccount: string }) => {
       await RlyNetwork.transfer(
         transferAddress,
         parseInt(transferBalance, 10),
-        customTokenAddress,
-        tokenTransactionType
+        customToken?.address,
+        customToken?.metaTxnMethod,
+        customToken
       );
       await fetchBalance();
       setTransferBalance('');

--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -15,14 +15,10 @@ import { useEffect, useState } from 'react';
 import {
   getAccountPhrase,
   RlyBaseSepoliaNetwork,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  RlyBaseNetwork,
   RlyAmoyNetwork,
   permanentlyDeleteAccount,
   walletBackedUpToCloud,
   updateWalletStorage,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  BaseUSDC,
   TokenConfig,
 } from '@rly-network/mobile-sdk';
 import { RlyCard } from './components/RlyCard';

--- a/example/src/AccountOverviewScreen.tsx
+++ b/example/src/AccountOverviewScreen.tsx
@@ -15,8 +15,8 @@ import { useEffect, useState } from 'react';
 import {
   getAccountPhrase,
   RlyBaseSepoliaNetwork,
-  RlyBaseNetwork,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  RlyBaseNetwork,
   RlyAmoyNetwork,
   permanentlyDeleteAccount,
   walletBackedUpToCloud,
@@ -29,7 +29,7 @@ import { RlyCard } from './components/RlyCard';
 import { LoadingModal, StandardModal } from './components/LoadingModal';
 import { PrivateConfig } from './private_config';
 
-const RlyNetwork = RlyBaseNetwork;
+const RlyNetwork = RlyAmoyNetwork;
 
 RlyNetwork.setApiKey(PrivateConfig.RALLY_API_KEY || '');
 

--- a/src/gsnClient/EIP712/typedSigning.ts
+++ b/src/gsnClient/EIP712/typedSigning.ts
@@ -74,6 +74,7 @@ export interface EIP712Domain {
   version?: string;
   chainId?: number;
   verifyingContract?: string;
+  salt?: string;
 }
 
 export class TypedGsnRequestData {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,3 +4,4 @@ import '@ethersproject/shims';
 export * from './account';
 export { MetaTxMethod } from './gsnClient/utils';
 export * from './network';
+export * from './transactions/supported_tokens';

--- a/src/networks/evm_network.ts
+++ b/src/networks/evm_network.ts
@@ -23,13 +23,15 @@ import type {
 
 import { MetaTxMethod } from '../gsnClient/utils';
 import { getProvider } from '../provider';
+import type { TokenConfig } from 'src/transactions/supported_tokens';
 
 async function transfer(
   destinationAddress: string,
   amount: number,
   network: NetworkConfig,
   tokenAddress?: PrefixedHexString,
-  metaTxMethod?: MetaTxMethod
+  metaTxMethod?: MetaTxMethod,
+  tokenConfig?: TokenConfig
 ): Promise<string> {
   const provider = getProvider(network);
 
@@ -50,7 +52,8 @@ async function transfer(
     amountBigNum.toString(),
     network,
     tokenAddress,
-    metaTxMethod
+    metaTxMethod,
+    tokenConfig
   );
 }
 
@@ -59,7 +62,8 @@ async function transferExact(
   amount: string,
   network: NetworkConfig,
   tokenAddress?: PrefixedHexString,
-  metaTxMethod?: MetaTxMethod
+  metaTxMethod?: MetaTxMethod,
+  tokenConfig?: TokenConfig
 ): Promise<string> {
   const provider = getProvider(network);
   const account = await getWallet();
@@ -94,7 +98,8 @@ async function transferExact(
         amountBigNum,
         network,
         tokenAddress,
-        provider
+        provider,
+        tokenConfig?.eip712Domain
       );
     } else {
       transferTx = await getExecuteMetatransactionTx(

--- a/src/transactions/supported_tokens.ts
+++ b/src/transactions/supported_tokens.ts
@@ -1,16 +1,49 @@
 import type { EIP712Domain } from '../gsnClient/EIP712/typedSigning';
 import { MetaTxMethod } from '../gsnClient/utils';
 
+/*
+ * TokenConfig is a configuration object that is used to define the properties of a token.
+ * address: The address of the token contract.
+ * metaTxnMethod: The method of meta transaction that the token supports. See MetaTxMethod for more information.
+ * This is most likely going to be MetaTxMethod.Permit.
+ * eip712Domain: The EIP712 domain object for the token. This is only required if the token uses non default values for EIP712 signature generation.
+ */
 export interface TokenConfig {
   address: string;
   metaTxnMethod: MetaTxMethod;
   eip712Domain?: EIP712Domain;
 }
 
+/*
+ * Pre built configuration for USDC on Base Mainnet
+ */
 export const BaseUSDC: TokenConfig = {
   address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
   metaTxnMethod: MetaTxMethod.Permit,
   eip712Domain: {
     version: '2',
   },
+};
+
+/*
+ * Pre built configuration for RLY on Sepolia Base.
+ * This is the token this SDK tests with by default.
+ */
+export const BaseSepoliaRLY: TokenConfig = {
+  address: '0x846D8a5fb8a003b431b67115f809a9B9FFFe5012',
+  metaTxnMethod: MetaTxMethod.Permit,
+  eip712Domain: {
+    version: '1',
+  },
+};
+
+/*
+ * This is a custom version of RLY configured to support
+ * the executeMetaTransaction style of meta transactions.
+ * Should only be used for specific testing purposes. If you aren't sure
+ * whether you need MetaTxMethod.ExecuteMetaTransaction, you probably don't.
+ */
+export const BaseSepoliaExecMetaRLY: TokenConfig = {
+  address: '0x16723e9bb894EfC09449994eC5bCF5b41EE0D9b2',
+  metaTxnMethod: MetaTxMethod.ExecuteMetaTransaction,
 };

--- a/src/transactions/supported_tokens.ts
+++ b/src/transactions/supported_tokens.ts
@@ -1,0 +1,16 @@
+import type { EIP712Domain } from '../gsnClient/EIP712/typedSigning';
+import { MetaTxMethod } from '../gsnClient/utils';
+
+export interface TokenConfig {
+  address: string;
+  metaTxnMethod: MetaTxMethod;
+  eip712Domain?: EIP712Domain;
+}
+
+export const BaseUSDC: TokenConfig = {
+  address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  metaTxnMethod: MetaTxMethod.Permit,
+  eip712Domain: {
+    version: '2',
+  },
+};


### PR DESCRIPTION
We do a lot of magic to determine things about how a transaction needs to be configured for a given token. That magic is brittle when run each time, and also hurts performance since these values are defined at contract deployment time. 

This begins the process of formalizing a `TokenConfig` and a pre-built set of tokens that we have configured on behalf of users. 

For now I am indexing into the object and passing around the whole object despite also indexing into it in a given call. This is to try and reduce the feature set and make the interface fully backwards compatible for now. In a future PR I will create a new top level interface that isn't backwards compatible. 