### PR TITLE
Fix issue with token transfers that attempt to use custom token config

### DIFF
--- a/src/networks/evm_network.ts
+++ b/src/networks/evm_network.ts
@@ -249,28 +249,32 @@ export function getEvmNetwork(network: NetworkConfig) {
       destinationAddress: string,
       amount: number,
       tokenAddress?: PrefixedHexString,
-      metaTxMethod?: MetaTxMethod
+      metaTxMethod?: MetaTxMethod,
+      tokenConfig?: TokenConfig
     ) {
       return transfer(
         destinationAddress,
         amount,
         network,
         tokenAddress,
-        metaTxMethod
+        metaTxMethod,
+        tokenConfig
       );
     },
     transferExact: function (
       destinationAddress: string,
       amount: string,
       tokenAddress?: PrefixedHexString,
-      metaTxMethod?: MetaTxMethod
+      metaTxMethod?: MetaTxMethod,
+      tokenConfig?: TokenConfig
     ) {
       return transferExact(
         destinationAddress,
         amount,
         network,
         tokenAddress,
-        metaTxMethod
+        metaTxMethod,
+        tokenConfig
       );
     },
     getBalance: function (tokenAddress?: PrefixedHexString) {


### PR DESCRIPTION
The token config was always nil because we didn't pass the right args
all the way through multiple layers of functional composition.
