### PR TITLE
Fix default salt value preventing signature generation

### DIFF
--- a/src/gsnClient/EIP712/PermitTransaction.ts
+++ b/src/gsnClient/EIP712/PermitTransaction.ts
@@ -184,7 +184,7 @@ export const getPermitTx = async (
     nonce.toNumber(),
     amount,
     deadline,
-    eip712DomainData?.salt || '',
+    eip712DomainData?.salt || ethers.constants.HashZero,
     eip712DomainData?.version
   );
 


### PR DESCRIPTION
Sneaky difference between languages that we never previously noticed
because the default value was never triggered. You need to use the
ethers 0 hex value, not an empty string in order for serialization necessary for signature
generation
